### PR TITLE
Bugfix: Fixes settingUI going blank on deleting a service

### DIFF
--- a/LaciSynchroni/Services/PerformanceCollectorService.cs
+++ b/LaciSynchroni/Services/PerformanceCollectorService.cs
@@ -1,4 +1,5 @@
-﻿using LaciSynchroni.SyncConfiguration;
+﻿using LaciSynchroni.Services.ServerConfiguration;
+using LaciSynchroni.SyncConfiguration;
 using LaciSynchroni.Utils;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
+++ b/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
@@ -40,6 +40,8 @@ public class ServerConfigurationManager
         _syncMediator = syncMediator;
     }
 
+    public bool AnyServerRegistered => _serverConfigService.Current.ServerStorage.Count > 0;
+
     public IEnumerable<int> ServerIndexes => _serverConfigService.Current.ServerStorage.Select((_, i) => i);
 
     public bool AnyServerConfigured => _serverTagConfig.Current.ServerTagStorage.Count > 0;
@@ -181,8 +183,7 @@ public class ServerConfigurationManager
             return storage[idx];
         }
 
-        _logger.LogWarning("The client tried to obtain data for a server that is not registered: {Idx}", idx);
-        return new();
+        throw new InvalidOperationException($"The client tried to obtain data for a server that is not registered: {idx}");
     }
 
     public string GetDiscordUserFromToken(ServerStorage server)

--- a/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
+++ b/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
@@ -175,7 +175,13 @@ public class ServerConfigurationManager
     
     public ServerStorage GetServerByIndex(int idx)
     {
-        return _serverConfigService.Current.ServerStorage[idx];
+        var storage = _serverConfigService.Current.ServerStorage;
+        if (idx >= 0 && idx < storage.Count)
+        {
+            return storage[idx];
+        }
+
+        return new();
     }
 
     public string GetDiscordUserFromToken(ServerStorage server)

--- a/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
+++ b/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
@@ -181,6 +181,7 @@ public class ServerConfigurationManager
             return storage[idx];
         }
 
+        _logger.LogWarning("The client tried to obtain data for a server that is not registered: {Idx}", idx);
         return new();
     }
 

--- a/LaciSynchroni/SyncConfiguration/Configurations/ServerConfig.cs
+++ b/LaciSynchroni/SyncConfiguration/Configurations/ServerConfig.cs
@@ -15,8 +15,5 @@ public class ServerConfig : ISyncConfiguration
 
     public bool SendCensusData { get; set; } = false;
     public bool ShownCensusPopup { get; set; } = false;
-    public bool ShowServerPickerInMainMenu { get; set; } = false;
-    public bool EnableMultiConnect { get; set; } = true;
-
     public int Version { get; set; } = 2;
 }

--- a/LaciSynchroni/UI/CompactUI.cs
+++ b/LaciSynchroni/UI/CompactUI.cs
@@ -395,7 +395,7 @@ public class CompactUi : WindowMediatorSubscriberBase
                 UiSharedService.AttachToolTip("Click to copy");
             }
         }
-        else if (_apiController.GetServerState(serverId) is not (ServerState.Disconnected or ServerState.Offline))
+        else if (_apiController.GetServerStateForServer(serverId) is not (ServerState.Disconnected or ServerState.Offline))
         {
             var errorText = GetServerErrorByServer(serverId);
             var origTextSize = ImGui.CalcTextSize(errorText);
@@ -521,18 +521,12 @@ public class CompactUi : WindowMediatorSubscriberBase
                 UiSharedService.AttachToolTip("Click to copy");
             }
         }
-        else if (_apiController.IsServerAlive(serverId))
-        {
-            var serverError = GetServerErrorByServer(serverId);
-            UiSharedService.ColorTextWrapped("Offline", ImGuiColors.DalamudYellow);
-
-            if (!string.IsNullOrEmpty(serverError))
-                UiSharedService.AttachToolTip(serverError);
-        }
         else
         {
+            var serverState = _apiController.GetServerStateForServer(serverId).ToString();
+            var uidErrorColor = GetUidColorByServer(serverId);
             var serverError = GetServerErrorByServer(serverId);
-            UiSharedService.ColorTextWrapped("Offline", ImGuiColors.DalamudRed);
+            UiSharedService.ColorTextWrapped(serverState, uidErrorColor);
 
             if (!string.IsNullOrEmpty(serverError))
                 UiSharedService.AttachToolTip(serverError);
@@ -541,7 +535,7 @@ public class CompactUi : WindowMediatorSubscriberBase
 
     private void DrawMultiServerConnectButton(int serverId, string serverName)
     {
-        bool isConnectingOrConnected = _apiController.IsServerConnected(serverId);
+        bool isConnectingOrConnected = _apiController.IsServerConnectingOrConnected(serverId);
         var color = UiSharedService.GetBoolColor(!isConnectingOrConnected);
         var connectedIcon = isConnectingOrConnected ? FontAwesomeIcon.Unlink : FontAwesomeIcon.Link;
 
@@ -549,7 +543,7 @@ public class CompactUi : WindowMediatorSubscriberBase
         {
             if (_uiSharedService.IconButton(connectedIcon, serverId.ToString()))
             {
-                if (_apiController.IsServerConnected(serverId))
+                if (isConnectingOrConnected)
                 {
                     _serverConfigManager.GetServerByIndex(serverId).FullPause = true;
                     _serverConfigManager.Save();
@@ -587,7 +581,7 @@ public class CompactUi : WindowMediatorSubscriberBase
 
     private string GetUidTextMultiServer(int serverId)
     {
-        return _apiController.GetServerState(serverId) switch
+        return _apiController.GetServerStateForServer(serverId) switch
         {
             ServerState.Connected => _apiController.GetUidByServer(serverId),
             _ => "Offline"
@@ -898,7 +892,7 @@ public class CompactUi : WindowMediatorSubscriberBase
     private string GetServerErrorByServer(int serverId)
     {
         var authFailureMessage = _apiController.GetAuthFailureMessageByServer(serverId);
-        return GetServerErrorByState(_apiController.GetServerState(serverId), authFailureMessage);
+        return GetServerErrorByState(_apiController.GetServerStateForServer(serverId), authFailureMessage);
     }
 
     private static string GetServerErrorByState(ServerState state, string? authFailureMessage)
@@ -926,7 +920,7 @@ public class CompactUi : WindowMediatorSubscriberBase
 
     private Vector4 GetUidColorByServer(int serverId)
     {
-        return GetUidColorByState(_apiController.GetServerState(serverId));
+        return GetUidColorByState(_apiController.GetServerStateForServer(serverId));
     }
 
     private static Vector4 GetUidColorByState(ServerState state)

--- a/LaciSynchroni/UI/IntroUI.cs
+++ b/LaciSynchroni/UI/IntroUI.cs
@@ -45,7 +45,6 @@ public partial class IntroUi : WindowMediatorSubscriberBase
         _serverConfigurationManager = serverConfigurationManager;
         _dalamudUtilService = dalamudUtilService;
         IsOpen = false;
-        ShowCloseButton = false;
         RespectCloseHotkey = false;
 
         SizeConstraints = new WindowSizeConstraints()
@@ -222,10 +221,18 @@ public partial class IntroUi : WindowMediatorSubscriberBase
 
             UiSharedService.TextWrapped("Once you have registered you can connect to the service using the tools provided below.");
 
+            if (!_serverConfigurationManager.AnyServerRegistered)
+            {
+                _uiShared.DrawAddCustomService(defaultOpen: true);
+                return;
+            }
+
             int serverIdx = 0;
             var selectedServer = _serverConfigurationManager.GetServerByIndex(serverIdx);
+            if (selectedServer is null)
+                return;
 
-            using (var node = ImRaii.TreeNode("Advanced Options"))
+            using (var node = ImRaii.TreeNode("Advanced Options", ImGuiTreeNodeFlags.DefaultOpen))
             {
                 if (node)
                 {

--- a/LaciSynchroni/UI/SettingsUi.cs
+++ b/LaciSynchroni/UI/SettingsUi.cs
@@ -1227,7 +1227,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         DrawMultiServerInterfaceTable();
         ImGui.Separator();
 
-        _uiShared.DrawAddCustomService();
+        _uiShared.DrawAddCustomService(defaultOpen: !_serverConfigurationManager.AnyServerRegistered);
         ImGui.Separator();
 
         DrawSpeedTest();
@@ -1235,570 +1235,571 @@ public class SettingsUi : WindowMediatorSubscriberBase
 
         ImGuiHelpers.ScaledDummy(new Vector2(10, 10));
 
+        if (!_serverConfigurationManager.AnyServerRegistered)
+            return;
+
         var selectedServer = _serverConfigurationManager.GetServerByIndex(_lastSelectedServerIndex);
         bool useOauth = selectedServer.UseOAuth2;
 
-        if (string.IsNullOrEmpty(_lastSelectedServerName))
-            _uiShared.BigText($"Service Settings");
-        else
-            _uiShared.BigText($"Settings for {_lastSelectedServerName} service");
+        if (selectedServer is null)
+            return;
 
-        using (ImRaii.Disabled(string.IsNullOrEmpty(_lastSelectedServerName)))
+        _uiShared.BigText($"Settings for {_lastSelectedServerName} service");
+
+
+        ImGuiHelpers.ScaledDummy(new Vector2(5, 5));
+        var sendCensus = _serverConfigurationManager.SendCensusData;
+        if (ImGui.Checkbox("Send Statistical Census Data", ref sendCensus))
         {
-            ImGuiHelpers.ScaledDummy(new Vector2(5, 5));
-            var sendCensus = _serverConfigurationManager.SendCensusData;
-            if (ImGui.Checkbox("Send Statistical Census Data", ref sendCensus))
-            {
-                _serverConfigurationManager.SendCensusData = sendCensus;
-            }
-            _uiShared.DrawHelpText("This will allow sending census data to the currently connected service." + UiSharedService.TooltipSeparator
-                + "Census data contains:" + Environment.NewLine
-                + "- Current World" + Environment.NewLine
-                + "- Current Gender" + Environment.NewLine
-                + "- Current Race" + Environment.NewLine
-                + "- Current Clan (this is not your Free Company, this is e.g. Keeper or Seeker for Miqo'te)" + UiSharedService.TooltipSeparator
-                + "The census data is only saved temporarily and will be removed from the server on disconnect. It is stored temporarily associated with your UID while you are connected." + UiSharedService.TooltipSeparator
-                + "If you do not wish to participate in the statistical census, untick this box and reconnect to the server.");
-            ImGuiHelpers.ScaledDummy(new Vector2(10, 10));
+            _serverConfigurationManager.SendCensusData = sendCensus;
+        }
+        _uiShared.DrawHelpText("This will allow sending census data to the currently connected service." + UiSharedService.TooltipSeparator
+            + "Census data contains:" + Environment.NewLine
+            + "- Current World" + Environment.NewLine
+            + "- Current Gender" + Environment.NewLine
+            + "- Current Race" + Environment.NewLine
+            + "- Current Clan (this is not your Free Company, this is e.g. Keeper or Seeker for Miqo'te)" + UiSharedService.TooltipSeparator
+            + "The census data is only saved temporarily and will be removed from the server on disconnect. It is stored temporarily associated with your UID while you are connected." + UiSharedService.TooltipSeparator
+            + "If you do not wish to participate in the statistical census, untick this box and reconnect to the server.");
+        ImGuiHelpers.ScaledDummy(new Vector2(10, 10));
 
-            if (ImGui.BeginTabBar("serverTabBar"))
+        if (ImGui.BeginTabBar("serverTabBar"))
+        {
+            if (ImGui.BeginTabItem("Service Configuration"))
             {
-                if (ImGui.BeginTabItem("Service Configuration"))
+                var serverName = selectedServer.ServerName;
+                var serverUri = selectedServer.ServerUri;
+                var serverHubUri = selectedServer.ServerHubUri ?? selectedServer.ServerUri;
+                var useAdvancedUris = selectedServer.UseAdvancedUris;
+
+                if (ImGui.InputText("Service Name", ref serverName, 255))
                 {
-                    var serverName = selectedServer.ServerName;
-                    var serverUri = selectedServer.ServerUri;
-                    var serverHubUri = selectedServer.ServerHubUri ?? selectedServer.ServerUri;
-                    var useAdvancedUris = selectedServer.UseAdvancedUris;
-
-                    if (ImGui.InputText("Service Name", ref serverName, 255))
-                    {
-                        selectedServer.ServerName = serverName;
-                        _serverConfigurationManager.Save();
-                    }
-
-                    if (ImGui.InputText("Service URI", ref serverUri, 255))
-                    {
-                        selectedServer.ServerUri = serverUri;
-                        _serverConfigurationManager.Save();
-                    }
-
-                    if (ImGui.Checkbox("Advanced URIs", ref useAdvancedUris))
-                    {
-                        selectedServer.UseAdvancedUris = useAdvancedUris;
-                        _serverConfigurationManager.Save();
-                    }
-
-                    _uiShared.DrawHelpText("Configure the API & Hub URI individually");
-                    if (useAdvancedUris)
-                    {
-                        if (ImGui.InputText("Service Hub URI", ref serverHubUri, 255))
-                        {
-                            selectedServer.ServerHubUri = serverHubUri;
-                            _serverConfigurationManager.Save();
-                        }
-                    }
-
-                    ImGui.SetNextItemWidth(200);
-                    var serverTransport = _serverConfigurationManager.GetTransport(_lastSelectedServerIndex);
-                    _uiShared.DrawCombo("Server Transport Type", Enum.GetValues<HttpTransportType>().Where(t => t != HttpTransportType.None),
-                        (v) => v.ToString(),
-                        onSelected: (t) => _serverConfigurationManager.SetTransportType(_lastSelectedServerIndex, t),
-                        serverTransport);
-                    _uiShared.DrawHelpText("You normally do not need to change this, if you don't know what this is or what it's for, keep it to WebSockets." + Environment.NewLine
-                        + "If you run into connection issues with e.g. VPNs, try ServerSentEvents first before trying out LongPolling." + UiSharedService.TooltipSeparator
-                        + "Note: if the server does not support a specific Transport Type it will fall through to the next automatically: WebSockets > ServerSentEvents > LongPolling");
-
-                    if (_dalamudUtilService.IsWine)
-                    {
-                        bool forceWebSockets = selectedServer.ForceWebSockets;
-                        if (ImGui.Checkbox("[wine only] Force WebSockets", ref forceWebSockets))
-                        {
-                            selectedServer.ForceWebSockets = forceWebSockets;
-                            _serverConfigurationManager.Save();
-                        }
-                        _uiShared.DrawHelpText("On Wine, Laci will automatically fall back to ServerSentEvents/LongPolling, even if WebSockets is selected. "
-                            + "WebSockets are known to crash XIV entirely on Wine 8.5 shipped with Dalamud. "
-                            + "Only enable this if you are not running Wine 8.5." + Environment.NewLine
-                            + "Note: If the issue gets resolved at some point this option will be removed.");
-                    }
-
-                    ImGuiHelpers.ScaledDummy(5);
-
-                    if (ImGui.Checkbox("Use Discord OAuth2 Authentication", ref useOauth))
-                    {
-                        selectedServer.UseOAuth2 = useOauth;
-                        _serverConfigurationManager.Save();
-                    }
-                    _uiShared.DrawHelpText("Use Discord OAuth2 Authentication to identify with this server instead of secret keys");
-                    if (useOauth)
-                    {
-                        _uiShared.DrawOAuth(_lastSelectedServerIndex, selectedServer);
-                        if (string.IsNullOrEmpty(_serverConfigurationManager.GetDiscordUserFromToken(selectedServer)))
-                        {
-                            ImGuiHelpers.ScaledDummy(10f);
-                            UiSharedService.ColorTextWrapped("You have enabled OAuth2 but it is not linked. Press the buttons Check, then Authenticate to link properly.", ImGuiColors.DalamudRed);
-                        }
-                        if (!string.IsNullOrEmpty(_serverConfigurationManager.GetDiscordUserFromToken(selectedServer))
-                            && selectedServer.Authentications.TrueForAll(u => string.IsNullOrEmpty(u.UID)))
-                        {
-                            ImGuiHelpers.ScaledDummy(10f);
-                            UiSharedService.ColorTextWrapped("You have enabled OAuth2 but no characters configured. Set the correct UIDs for your characters in \"Character Management\".",
-                                ImGuiColors.DalamudRed);
-                        }
-                    }
-
-                    ImGui.Separator();
-
-                    var isServerConnected = _apiController.IsServerConnected(_lastSelectedServerIndex);
-                    if (isServerConnected)
-                    {
-                        UiSharedService.ColorTextWrapped($"To delete the {serverName} service you need to disconnect from the service.", ImGuiColors.DalamudYellow);
-                    }
-
-                    using (ImRaii.Disabled(isServerConnected))
-                    {
-                        if (_uiShared.IconTextButton(FontAwesomeIcon.Trash, "Delete Service") && UiSharedService.CtrlPressed())
-                        {
-                            _serverConfigurationManager.DeleteServer(selectedServer);
-                        }
-                    }
-
-                    _uiShared.DrawHelpText("Hold CTRL to delete this service");
-
-                    ImGui.EndTabItem();
+                    selectedServer.ServerName = serverName;
+                    _serverConfigurationManager.Save();
                 }
 
-                if (ImGui.BeginTabItem("Character Management"))
+                if (ImGui.InputText("Service URI", ref serverUri, 255))
                 {
-                    if (selectedServer.SecretKeys.Any() || useOauth)
-                    {
-                        UiSharedService.ColorTextWrapped("Characters listed here will automatically connect to the selected service with the settings as provided below." +
-                            " Make sure to enter the character names correctly or use the 'Add current character' button at the bottom.", ImGuiColors.DalamudYellow);
-                        int i = 0;
-                        _uiShared.DrawUpdateOAuthUIDsButton(selectedServer);
+                    selectedServer.ServerUri = serverUri;
+                    _serverConfigurationManager.Save();
+                }
 
-                        if (selectedServer.UseOAuth2 && !string.IsNullOrEmpty(selectedServer.OAuthToken))
+                if (ImGui.Checkbox("Advanced URIs", ref useAdvancedUris))
+                {
+                    selectedServer.UseAdvancedUris = useAdvancedUris;
+                    _serverConfigurationManager.Save();
+                }
+
+                _uiShared.DrawHelpText("Configure the API & Hub URI individually");
+                if (useAdvancedUris)
+                {
+                    if (ImGui.InputText("Service Hub URI", ref serverHubUri, 255))
+                    {
+                        selectedServer.ServerHubUri = serverHubUri;
+                        _serverConfigurationManager.Save();
+                    }
+                }
+
+                ImGui.SetNextItemWidth(200);
+                var serverTransport = _serverConfigurationManager.GetTransport(_lastSelectedServerIndex);
+                _uiShared.DrawCombo("Server Transport Type", Enum.GetValues<HttpTransportType>().Where(t => t != HttpTransportType.None),
+                    (v) => v.ToString(),
+                    onSelected: (t) => _serverConfigurationManager.SetTransportType(_lastSelectedServerIndex, t),
+                    serverTransport);
+                _uiShared.DrawHelpText("You normally do not need to change this, if you don't know what this is or what it's for, keep it to WebSockets." + Environment.NewLine
+                    + "If you run into connection issues with e.g. VPNs, try ServerSentEvents first before trying out LongPolling." + UiSharedService.TooltipSeparator
+                    + "Note: if the server does not support a specific Transport Type it will fall through to the next automatically: WebSockets > ServerSentEvents > LongPolling");
+
+                if (_dalamudUtilService.IsWine)
+                {
+                    bool forceWebSockets = selectedServer.ForceWebSockets;
+                    if (ImGui.Checkbox("[wine only] Force WebSockets", ref forceWebSockets))
+                    {
+                        selectedServer.ForceWebSockets = forceWebSockets;
+                        _serverConfigurationManager.Save();
+                    }
+                    _uiShared.DrawHelpText("On Wine, Laci will automatically fall back to ServerSentEvents/LongPolling, even if WebSockets is selected. "
+                        + "WebSockets are known to crash XIV entirely on Wine 8.5 shipped with Dalamud. "
+                        + "Only enable this if you are not running Wine 8.5." + Environment.NewLine
+                        + "Note: If the issue gets resolved at some point this option will be removed.");
+                }
+
+                ImGuiHelpers.ScaledDummy(5);
+
+                if (ImGui.Checkbox("Use Discord OAuth2 Authentication", ref useOauth))
+                {
+                    selectedServer.UseOAuth2 = useOauth;
+                    _serverConfigurationManager.Save();
+                }
+                _uiShared.DrawHelpText("Use Discord OAuth2 Authentication to identify with this server instead of secret keys");
+                if (useOauth)
+                {
+                    _uiShared.DrawOAuth(_lastSelectedServerIndex, selectedServer);
+                    if (string.IsNullOrEmpty(_serverConfigurationManager.GetDiscordUserFromToken(selectedServer)))
+                    {
+                        ImGuiHelpers.ScaledDummy(10f);
+                        UiSharedService.ColorTextWrapped("You have enabled OAuth2 but it is not linked. Press the buttons Check, then Authenticate to link properly.", ImGuiColors.DalamudRed);
+                    }
+                    if (!string.IsNullOrEmpty(_serverConfigurationManager.GetDiscordUserFromToken(selectedServer))
+                        && selectedServer.Authentications.TrueForAll(u => string.IsNullOrEmpty(u.UID)))
+                    {
+                        ImGuiHelpers.ScaledDummy(10f);
+                        UiSharedService.ColorTextWrapped("You have enabled OAuth2 but no characters configured. Set the correct UIDs for your characters in \"Character Management\".",
+                            ImGuiColors.DalamudRed);
+                    }
+                }
+
+                ImGui.Separator();
+
+                var isServerConnected = _apiController.IsServerConnected(_lastSelectedServerIndex);
+                if (isServerConnected)
+                {
+                    UiSharedService.ColorTextWrapped($"To delete the {serverName} service you need to disconnect from the service.", ImGuiColors.DalamudYellow);
+                }
+
+                using (ImRaii.Disabled(isServerConnected))
+                {
+                    if (_uiShared.IconTextButton(FontAwesomeIcon.Trash, "Delete Service") && UiSharedService.CtrlPressed())
+                    {
+                        _serverConfigurationManager.DeleteServer(selectedServer);
+                    }
+                }
+
+                _uiShared.DrawHelpText("Hold CTRL to delete this service");
+
+                ImGui.EndTabItem();
+            }
+
+            if (ImGui.BeginTabItem("Character Management"))
+            {
+                if (selectedServer.SecretKeys.Any() || useOauth)
+                {
+                    UiSharedService.ColorTextWrapped("Characters listed here will automatically connect to the selected service with the settings as provided below." +
+                        " Make sure to enter the character names correctly or use the 'Add current character' button at the bottom.", ImGuiColors.DalamudYellow);
+                    int i = 0;
+                    _uiShared.DrawUpdateOAuthUIDsButton(selectedServer);
+
+                    if (selectedServer.UseOAuth2 && !string.IsNullOrEmpty(selectedServer.OAuthToken))
+                    {
+                        bool hasSetSecretKeysButNoUid = selectedServer.Authentications.Exists(u => u.SecretKeyIdx != -1 && string.IsNullOrEmpty(u.UID));
+                        if (hasSetSecretKeysButNoUid)
                         {
-                            bool hasSetSecretKeysButNoUid = selectedServer.Authentications.Exists(u => u.SecretKeyIdx != -1 && string.IsNullOrEmpty(u.UID));
-                            if (hasSetSecretKeysButNoUid)
+                            ImGui.Dummy(new(5f, 5f));
+                            UiSharedService.TextWrapped("Some entries have been detected that have previously been assigned secret keys but not UIDs. " +
+                                "Press this button below to attempt to convert those entries.");
+                            using (ImRaii.Disabled(_secretKeysConversionTask != null && !_secretKeysConversionTask.IsCompleted))
                             {
-                                ImGui.Dummy(new(5f, 5f));
-                                UiSharedService.TextWrapped("Some entries have been detected that have previously been assigned secret keys but not UIDs. " +
-                                    "Press this button below to attempt to convert those entries.");
-                                using (ImRaii.Disabled(_secretKeysConversionTask != null && !_secretKeysConversionTask.IsCompleted))
+                                if (_uiShared.IconTextButton(FontAwesomeIcon.ArrowsLeftRight, "Try to Convert Secret Keys to UIDs"))
                                 {
-                                    if (_uiShared.IconTextButton(FontAwesomeIcon.ArrowsLeftRight, "Try to Convert Secret Keys to UIDs"))
-                                    {
-                                        _secretKeysConversionTask = ConvertSecretKeysToUIDs(selectedServer, _secretKeysConversionCts.Token);
-                                    }
+                                    _secretKeysConversionTask = ConvertSecretKeysToUIDs(selectedServer, _secretKeysConversionCts.Token);
                                 }
-                                if (_secretKeysConversionTask != null && !_secretKeysConversionTask.IsCompleted)
+                            }
+                            if (_secretKeysConversionTask != null && !_secretKeysConversionTask.IsCompleted)
+                            {
+                                UiSharedService.ColorTextWrapped("Converting Secret Keys to UIDs", ImGuiColors.DalamudYellow);
+                            }
+                            if (_secretKeysConversionTask != null && _secretKeysConversionTask.IsCompletedSuccessfully)
+                            {
+                                Vector4? textColor = null;
+                                if (_secretKeysConversionTask.Result.PartialSuccess)
                                 {
-                                    UiSharedService.ColorTextWrapped("Converting Secret Keys to UIDs", ImGuiColors.DalamudYellow);
+                                    textColor = ImGuiColors.DalamudYellow;
                                 }
-                                if (_secretKeysConversionTask != null && _secretKeysConversionTask.IsCompletedSuccessfully)
+                                if (!_secretKeysConversionTask.Result.Success)
                                 {
-                                    Vector4? textColor = null;
-                                    if (_secretKeysConversionTask.Result.PartialSuccess)
-                                    {
-                                        textColor = ImGuiColors.DalamudYellow;
-                                    }
-                                    if (!_secretKeysConversionTask.Result.Success)
-                                    {
-                                        textColor = ImGuiColors.DalamudRed;
-                                    }
-                                    string text = $"Conversion has completed: {_secretKeysConversionTask.Result.Result}";
-                                    if (textColor == null)
-                                    {
-                                        UiSharedService.TextWrapped(text);
-                                    }
-                                    else
-                                    {
-                                        UiSharedService.ColorTextWrapped(text, textColor!.Value);
-                                    }
-                                    if (!_secretKeysConversionTask.Result.Success || _secretKeysConversionTask.Result.PartialSuccess)
-                                    {
-                                        UiSharedService.TextWrapped("In case of conversion failures, please set the UIDs for the failed conversions manually.");
-                                    }
+                                    textColor = ImGuiColors.DalamudRed;
+                                }
+                                string text = $"Conversion has completed: {_secretKeysConversionTask.Result.Result}";
+                                if (textColor == null)
+                                {
+                                    UiSharedService.TextWrapped(text);
+                                }
+                                else
+                                {
+                                    UiSharedService.ColorTextWrapped(text, textColor!.Value);
+                                }
+                                if (!_secretKeysConversionTask.Result.Success || _secretKeysConversionTask.Result.PartialSuccess)
+                                {
+                                    UiSharedService.TextWrapped("In case of conversion failures, please set the UIDs for the failed conversions manually.");
                                 }
                             }
                         }
-                        ImGui.Separator();
-                        string youName = _dalamudUtilService.GetPlayerName();
-                        uint youWorld = _dalamudUtilService.GetHomeWorldId();
-                        ulong youCid = _dalamudUtilService.GetCID();
-                        if (!selectedServer.Authentications.Exists(a => string.Equals(a.CharacterName, youName, StringComparison.Ordinal) && a.WorldId == youWorld))
+                    }
+                    ImGui.Separator();
+                    string youName = _dalamudUtilService.GetPlayerName();
+                    uint youWorld = _dalamudUtilService.GetHomeWorldId();
+                    ulong youCid = _dalamudUtilService.GetCID();
+                    if (!selectedServer.Authentications.Exists(a => string.Equals(a.CharacterName, youName, StringComparison.Ordinal) && a.WorldId == youWorld))
+                    {
+                        _uiShared.BigText("Your Character is not Configured", ImGuiColors.DalamudRed);
+                        UiSharedService.ColorTextWrapped("You have currently no character configured that corresponds to your current name and world.", ImGuiColors.DalamudRed);
+                        var authWithCid = selectedServer.Authentications.Find(f => f.LastSeenCID == youCid);
+                        if (authWithCid != null)
                         {
-                            _uiShared.BigText("Your Character is not Configured", ImGuiColors.DalamudRed);
-                            UiSharedService.ColorTextWrapped("You have currently no character configured that corresponds to your current name and world.", ImGuiColors.DalamudRed);
-                            var authWithCid = selectedServer.Authentications.Find(f => f.LastSeenCID == youCid);
-                            if (authWithCid != null)
+                            ImGuiHelpers.ScaledDummy(5);
+                            UiSharedService.ColorText("A potential rename/world change from this character was detected:", ImGuiColors.DalamudYellow);
+                            using (ImRaii.PushIndent(10f))
+                                UiSharedService.ColorText("Entry: " + authWithCid.CharacterName + " - " + _dalamudUtilService.WorldData.Value[(ushort)authWithCid.WorldId], ImGuiColors.ParsedGreen);
+                            UiSharedService.ColorText("Press the button below to adjust that entry to your current character:", ImGuiColors.DalamudYellow);
+                            using (ImRaii.PushIndent(10f))
+                                UiSharedService.ColorText("Current: " + youName + " - " + _dalamudUtilService.WorldData.Value[(ushort)youWorld], ImGuiColors.ParsedGreen);
+                            ImGuiHelpers.ScaledDummy(5);
+                            if (_uiShared.IconTextButton(FontAwesomeIcon.ArrowRight, "Update Entry to Current Character"))
                             {
-                                ImGuiHelpers.ScaledDummy(5);
-                                UiSharedService.ColorText("A potential rename/world change from this character was detected:", ImGuiColors.DalamudYellow);
-                                using (ImRaii.PushIndent(10f))
-                                    UiSharedService.ColorText("Entry: " + authWithCid.CharacterName + " - " + _dalamudUtilService.WorldData.Value[(ushort)authWithCid.WorldId], ImGuiColors.ParsedGreen);
-                                UiSharedService.ColorText("Press the button below to adjust that entry to your current character:", ImGuiColors.DalamudYellow);
-                                using (ImRaii.PushIndent(10f))
-                                    UiSharedService.ColorText("Current: " + youName + " - " + _dalamudUtilService.WorldData.Value[(ushort)youWorld], ImGuiColors.ParsedGreen);
-                                ImGuiHelpers.ScaledDummy(5);
-                                if (_uiShared.IconTextButton(FontAwesomeIcon.ArrowRight, "Update Entry to Current Character"))
+                                authWithCid.CharacterName = youName;
+                                authWithCid.WorldId = youWorld;
+                                _serverConfigurationManager.Save();
+                            }
+                        }
+                        ImGuiHelpers.ScaledDummy(5);
+                        ImGui.Separator();
+                        ImGuiHelpers.ScaledDummy(5);
+                    }
+                    foreach (var item in selectedServer.Authentications.ToList())
+                    {
+                        using var charaId = ImRaii.PushId("selectedChara" + i);
+
+                        var worldIdx = (ushort)item.WorldId;
+                        var data = _uiShared.WorldData.OrderBy(u => u.Value, StringComparer.Ordinal).ToDictionary(k => k.Key, k => k.Value);
+                        if (!data.TryGetValue(worldIdx, out string? worldPreview))
+                        {
+                            worldPreview = data.First().Value;
+                        }
+
+                        Dictionary<int, SecretKey> keys = [];
+
+                        if (!useOauth)
+                        {
+                            var secretKeyIdx = item.SecretKeyIdx;
+                            keys = selectedServer.SecretKeys;
+                            if (!keys.TryGetValue(secretKeyIdx, out var secretKey))
+                            {
+                                secretKey = new();
+                            }
+                        }
+
+                        bool thisIsYou = false;
+                        if (string.Equals(youName, item.CharacterName, StringComparison.OrdinalIgnoreCase)
+                            && youWorld == worldIdx)
+                        {
+                            thisIsYou = true;
+                        }
+                        bool misManaged = false;
+                        if (selectedServer.UseOAuth2 && !string.IsNullOrEmpty(selectedServer.OAuthToken) && string.IsNullOrEmpty(item.UID))
+                        {
+                            misManaged = true;
+                        }
+                        if (!selectedServer.UseOAuth2 && item.SecretKeyIdx == -1)
+                        {
+                            misManaged = true;
+                        }
+                        Vector4 color = ImGuiColors.ParsedGreen;
+                        string text = thisIsYou ? "Your Current Character" : string.Empty;
+                        if (misManaged)
+                        {
+                            text += " [MISMANAGED (" + (selectedServer.UseOAuth2 ? "No UID Set" : "No Secret Key Set") + ")]";
+                            color = ImGuiColors.DalamudRed;
+                        }
+                        if (selectedServer.Authentications.Where(e => e != item).Any(e => string.Equals(e.CharacterName, item.CharacterName, StringComparison.Ordinal)
+                            && e.WorldId == item.WorldId))
+                        {
+                            text += " [DUPLICATE]";
+                            color = ImGuiColors.DalamudRed;
+                        }
+
+                        if (!string.IsNullOrEmpty(text))
+                        {
+                            text = text.Trim();
+                            _uiShared.BigText(text, color);
+                        }
+
+                        var charaName = item.CharacterName;
+                        if (ImGui.InputText("Character Name", ref charaName, 64))
+                        {
+                            item.CharacterName = charaName;
+                            _serverConfigurationManager.Save();
+                        }
+
+                        _uiShared.DrawCombo("World##" + item.CharacterName + i, data, (w) => w.Value,
+                            (w) =>
+                            {
+                                if (item.WorldId != w.Key)
                                 {
-                                    authWithCid.CharacterName = youName;
-                                    authWithCid.WorldId = youWorld;
+                                    item.WorldId = w.Key;
                                     _serverConfigurationManager.Save();
                                 }
-                            }
-                            ImGuiHelpers.ScaledDummy(5);
-                            ImGui.Separator();
-                            ImGuiHelpers.ScaledDummy(5);
-                        }
-                        foreach (var item in selectedServer.Authentications.ToList())
+                            }, EqualityComparer<KeyValuePair<ushort, string>>.Default.Equals(data.FirstOrDefault(f => f.Key == worldIdx), default) ? data.First() : data.First(f => f.Key == worldIdx));
+
+                        if (!useOauth)
                         {
-                            using var charaId = ImRaii.PushId("selectedChara" + i);
-
-                            var worldIdx = (ushort)item.WorldId;
-                            var data = _uiShared.WorldData.OrderBy(u => u.Value, StringComparer.Ordinal).ToDictionary(k => k.Key, k => k.Value);
-                            if (!data.TryGetValue(worldIdx, out string? worldPreview))
-                            {
-                                worldPreview = data.First().Value;
-                            }
-
-                            Dictionary<int, SecretKey> keys = [];
-
-                            if (!useOauth)
-                            {
-                                var secretKeyIdx = item.SecretKeyIdx;
-                                keys = selectedServer.SecretKeys;
-                                if (!keys.TryGetValue(secretKeyIdx, out var secretKey))
-                                {
-                                    secretKey = new();
-                                }
-                            }
-
-                            bool thisIsYou = false;
-                            if (string.Equals(youName, item.CharacterName, StringComparison.OrdinalIgnoreCase)
-                                && youWorld == worldIdx)
-                            {
-                                thisIsYou = true;
-                            }
-                            bool misManaged = false;
-                            if (selectedServer.UseOAuth2 && !string.IsNullOrEmpty(selectedServer.OAuthToken) && string.IsNullOrEmpty(item.UID))
-                            {
-                                misManaged = true;
-                            }
-                            if (!selectedServer.UseOAuth2 && item.SecretKeyIdx == -1)
-                            {
-                                misManaged = true;
-                            }
-                            Vector4 color = ImGuiColors.ParsedGreen;
-                            string text = thisIsYou ? "Your Current Character" : string.Empty;
-                            if (misManaged)
-                            {
-                                text += " [MISMANAGED (" + (selectedServer.UseOAuth2 ? "No UID Set" : "No Secret Key Set") + ")]";
-                                color = ImGuiColors.DalamudRed;
-                            }
-                            if (selectedServer.Authentications.Where(e => e != item).Any(e => string.Equals(e.CharacterName, item.CharacterName, StringComparison.Ordinal)
-                                && e.WorldId == item.WorldId))
-                            {
-                                text += " [DUPLICATE]";
-                                color = ImGuiColors.DalamudRed;
-                            }
-
-                            if (!string.IsNullOrEmpty(text))
-                            {
-                                text = text.Trim();
-                                _uiShared.BigText(text, color);
-                            }
-
-                            var charaName = item.CharacterName;
-                            if (ImGui.InputText("Character Name", ref charaName, 64))
-                            {
-                                item.CharacterName = charaName;
-                                _serverConfigurationManager.Save();
-                            }
-
-                            _uiShared.DrawCombo("World##" + item.CharacterName + i, data, (w) => w.Value,
-                                (w) =>
-                                {
-                                    if (item.WorldId != w.Key)
-                                    {
-                                        item.WorldId = w.Key;
-                                        _serverConfigurationManager.Save();
-                                    }
-                                }, EqualityComparer<KeyValuePair<ushort, string>>.Default.Equals(data.FirstOrDefault(f => f.Key == worldIdx), default) ? data.First() : data.First(f => f.Key == worldIdx));
-
-                            if (!useOauth)
-                            {
-                                var imGuiId = "Secret Key###" + item.CharacterName + _lastSelectedServerIndex + i;
-                                var comparator = EqualityComparer<KeyValuePair<int, SecretKey>>.Default.Equals(keys.FirstOrDefault(f => f.Key == item.SecretKeyIdx), default) ? keys.First() : keys.First(f => f.Key == item.SecretKeyIdx);
-                                _uiShared.DrawCombo(imGuiId, keys, (w) => w.Value.FriendlyName, (w) => ChangeSecretKey(w.Key, item), comparator);
-                            }
-                            else
-                            {
-                                _uiShared.DrawUIDComboForAuthentication(i, item, selectedServer.ServerUri, _logger);
-                            }
-                            bool isAutoLogin = item.AutoLogin;
-                            if (ImGui.Checkbox("Automatically login to service", ref isAutoLogin))
-                            {
-                                item.AutoLogin = isAutoLogin;
-                                _serverConfigurationManager.Save();
-                            }
-                            _uiShared.DrawHelpText("When enabled and logging into this character in XIV, Laci will automatically connect to the current service.");
-                            if (_uiShared.IconTextButton(FontAwesomeIcon.Trash, "Delete Character") && UiSharedService.CtrlPressed())
-                                _serverConfigurationManager.RemoveCharacterFromServer(_lastSelectedServerIndex, item);
-                            UiSharedService.AttachToolTip("Hold CTRL to delete this entry.");
-
-                            i++;
-                            if (item != selectedServer.Authentications.ToList()[^1])
-                            {
-                                ImGuiHelpers.ScaledDummy(5);
-                                ImGui.Separator();
-                                ImGuiHelpers.ScaledDummy(5);
-                            }
-                        }
-
-                        if (selectedServer.Authentications.Any())
-                            ImGui.Separator();
-
-                        if (!selectedServer.Authentications.Exists(c => string.Equals(c.CharacterName, youName, StringComparison.Ordinal)
-                            && c.WorldId == youWorld))
-                        {
-                            if (_uiShared.IconTextButton(FontAwesomeIcon.User, "Add current character"))
-                            {
-                                _serverConfigurationManager.AddCurrentCharacterToServer(_lastSelectedServerIndex);
-                            }
-                            ImGui.SameLine();
-                        }
-
-                        if (_uiShared.IconTextButton(FontAwesomeIcon.Plus, "Add new character"))
-                        {
-                            _serverConfigurationManager.AddEmptyCharacterToServer(_lastSelectedServerIndex);
-                        }
-                    }
-                    else
-                    {
-                        UiSharedService.ColorTextWrapped("You need to add a Secret Key first before adding Characters.", ImGuiColors.DalamudYellow);
-                    }
-
-                    ImGui.EndTabItem();
-                }
-
-                if (!useOauth && ImGui.BeginTabItem("Secret Key Management"))
-                {
-                    foreach (var item in selectedServer.SecretKeys.ToList())
-                    {
-                        using var id = ImRaii.PushId("key" + item.Key);
-                        var friendlyName = item.Value.FriendlyName;
-                        if (ImGui.InputText("Secret Key Display Name", ref friendlyName, 255))
-                        {
-                            item.Value.FriendlyName = friendlyName;
-                            _serverConfigurationManager.Save();
-                        }
-                        var key = item.Value.Key;
-                        if (ImGui.InputText("Secret Key", ref key, 64))
-                        {
-                            item.Value.Key = key;
-                            _serverConfigurationManager.Save();
-                        }
-                        if (!selectedServer.Authentications.Exists(p => p.SecretKeyIdx == item.Key))
-                        {
-                            if (_uiShared.IconTextButton(FontAwesomeIcon.Trash, "Delete Secret Key") && UiSharedService.CtrlPressed())
-                            {
-                                selectedServer.SecretKeys.Remove(item.Key);
-                                _serverConfigurationManager.Save();
-                            }
-                            UiSharedService.AttachToolTip("Hold CTRL to delete this secret key entry");
+                            var imGuiId = "Secret Key###" + item.CharacterName + _lastSelectedServerIndex + i;
+                            var comparator = EqualityComparer<KeyValuePair<int, SecretKey>>.Default.Equals(keys.FirstOrDefault(f => f.Key == item.SecretKeyIdx), default) ? keys.First() : keys.First(f => f.Key == item.SecretKeyIdx);
+                            _uiShared.DrawCombo(imGuiId, keys, (w) => w.Value.FriendlyName, (w) => ChangeSecretKey(w.Key, item), comparator);
                         }
                         else
                         {
-                            UiSharedService.ColorTextWrapped("This key is in use and cannot be deleted", ImGuiColors.DalamudYellow);
+                            _uiShared.DrawUIDComboForAuthentication(i, item, selectedServer.ServerUri, _logger);
                         }
-
-                        if (item.Key != selectedServer.SecretKeys.Keys.LastOrDefault())
-                            ImGui.Separator();
-                    }
-
-                    ImGui.Separator();
-                    if (_uiShared.IconTextButton(FontAwesomeIcon.Plus, "Add new Secret Key"))
-                    {
-                        selectedServer.SecretKeys.Add(selectedServer.SecretKeys.Any() ? selectedServer.SecretKeys.Max(p => p.Key) + 1 : 0, new SecretKey()
+                        bool isAutoLogin = item.AutoLogin;
+                        if (ImGui.Checkbox("Automatically login to service", ref isAutoLogin))
                         {
-                            FriendlyName = "New Secret Key",
-                        });
-                        _serverConfigurationManager.Save();
+                            item.AutoLogin = isAutoLogin;
+                            _serverConfigurationManager.Save();
+                        }
+                        _uiShared.DrawHelpText("When enabled and logging into this character in XIV, Laci will automatically connect to the current service.");
+                        if (_uiShared.IconTextButton(FontAwesomeIcon.Trash, "Delete Character") && UiSharedService.CtrlPressed())
+                            _serverConfigurationManager.RemoveCharacterFromServer(_lastSelectedServerIndex, item);
+                        UiSharedService.AttachToolTip("Hold CTRL to delete this entry.");
+
+                        i++;
+                        if (item != selectedServer.Authentications.ToList()[^1])
+                        {
+                            ImGuiHelpers.ScaledDummy(5);
+                            ImGui.Separator();
+                            ImGuiHelpers.ScaledDummy(5);
+                        }
                     }
 
-                    ImGui.EndTabItem();
+                    if (selectedServer.Authentications.Any())
+                        ImGui.Separator();
+
+                    if (!selectedServer.Authentications.Exists(c => string.Equals(c.CharacterName, youName, StringComparison.Ordinal)
+                        && c.WorldId == youWorld))
+                    {
+                        if (_uiShared.IconTextButton(FontAwesomeIcon.User, "Add current character"))
+                        {
+                            _serverConfigurationManager.AddCurrentCharacterToServer(_lastSelectedServerIndex);
+                        }
+                        ImGui.SameLine();
+                    }
+
+                    if (_uiShared.IconTextButton(FontAwesomeIcon.Plus, "Add new character"))
+                    {
+                        _serverConfigurationManager.AddEmptyCharacterToServer(_lastSelectedServerIndex);
+                    }
+                }
+                else
+                {
+                    UiSharedService.ColorTextWrapped("You need to add a Secret Key first before adding Characters.", ImGuiColors.DalamudYellow);
                 }
 
-                if (ImGui.BeginTabItem("Permission Settings"))
-                {
-                    _uiShared.BigText("Default Permission Settings");
-                    if (_apiController.IsServerConnected(_lastSelectedServerIndex))
-                    {
-                        UiSharedService.TextWrapped("Note: The default permissions settings here are not applied retroactively to existing pairs or joined Syncshells.");
-                        UiSharedService.TextWrapped("Note: The default permissions settings here are sent and stored on the connected service.");
-                        ImGuiHelpers.ScaledDummy(5f);
-                        var perms = _apiController.GetDefaultPermissionsForServer(_lastSelectedServerIndex)!;
-                        bool individualIsSticky = perms.IndividualIsSticky;
-                        bool disableIndividualSounds = perms.DisableIndividualSounds;
-                        bool disableIndividualAnimations = perms.DisableIndividualAnimations;
-                        bool disableIndividualVFX = perms.DisableIndividualVFX;
-                        if (ImGui.Checkbox("Individually set permissions become preferred permissions", ref individualIsSticky))
-                        {
-                            perms.IndividualIsSticky = individualIsSticky;
-                            _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
-                        }
-                        _uiShared.DrawHelpText("The preferred attribute means that the permissions to that user will never change through any of your permission changes to Syncshells " +
-                            "(i.e. if you have paused one specific user in a Syncshell and they become preferred permissions, then pause and unpause the same Syncshell, the user will remain paused - " +
-                            "if a user does not have preferred permissions, it will follow the permissions of the Syncshell and be unpaused)." + Environment.NewLine + Environment.NewLine +
-                            "This setting means:" + Environment.NewLine +
-                            "  - All new individual pairs get their permissions defaulted to preferred permissions." + Environment.NewLine +
-                            "  - All individually set permissions for any pair will also automatically become preferred permissions. This includes pairs in Syncshells." + Environment.NewLine + Environment.NewLine +
-                            "It is possible to remove or set the preferred permission state for any pair at any time." + Environment.NewLine + Environment.NewLine +
-                            "If unsure, leave this setting off.");
-                        ImGuiHelpers.ScaledDummy(3f);
+                ImGui.EndTabItem();
+            }
 
-                        if (ImGui.Checkbox("Disable individual pair sounds", ref disableIndividualSounds))
+            if (!useOauth && ImGui.BeginTabItem("Secret Key Management"))
+            {
+                foreach (var item in selectedServer.SecretKeys.ToList())
+                {
+                    using var id = ImRaii.PushId("key" + item.Key);
+                    var friendlyName = item.Value.FriendlyName;
+                    if (ImGui.InputText("Secret Key Display Name", ref friendlyName, 255))
+                    {
+                        item.Value.FriendlyName = friendlyName;
+                        _serverConfigurationManager.Save();
+                    }
+                    var key = item.Value.Key;
+                    if (ImGui.InputText("Secret Key", ref key, 64))
+                    {
+                        item.Value.Key = key;
+                        _serverConfigurationManager.Save();
+                    }
+                    if (!selectedServer.Authentications.Exists(p => p.SecretKeyIdx == item.Key))
+                    {
+                        if (_uiShared.IconTextButton(FontAwesomeIcon.Trash, "Delete Secret Key") && UiSharedService.CtrlPressed())
                         {
-                            perms.DisableIndividualSounds = disableIndividualSounds;
-                            _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                            selectedServer.SecretKeys.Remove(item.Key);
+                            _serverConfigurationManager.Save();
                         }
-                        _uiShared.DrawHelpText("This setting will disable sound sync for all new individual pairs.");
-                        if (ImGui.Checkbox("Disable individual pair animations", ref disableIndividualAnimations))
-                        {
-                            perms.DisableIndividualAnimations = disableIndividualAnimations;
-                            _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
-                        }
-                        _uiShared.DrawHelpText("This setting will disable animation sync for all new individual pairs.");
-                        if (ImGui.Checkbox("Disable individual pair VFX", ref disableIndividualVFX))
-                        {
-                            perms.DisableIndividualVFX = disableIndividualVFX;
-                            _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
-                        }
-                        _uiShared.DrawHelpText("This setting will disable VFX sync for all new individual pairs.");
-                        ImGuiHelpers.ScaledDummy(5f);
-                        bool disableGroundSounds = perms.DisableGroupSounds;
-                        bool disableGroupAnimations = perms.DisableGroupAnimations;
-                        bool disableGroupVFX = perms.DisableGroupVFX;
-                        if (ImGui.Checkbox("Disable Syncshell pair sounds", ref disableGroundSounds))
-                        {
-                            perms.DisableGroupSounds = disableGroundSounds;
-                            _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
-                        }
-                        _uiShared.DrawHelpText("This setting will disable sound sync for all non-sticky pairs in newly joined syncshells.");
-                        if (ImGui.Checkbox("Disable Syncshell pair animations", ref disableGroupAnimations))
-                        {
-                            perms.DisableGroupAnimations = disableGroupAnimations;
-                            _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
-                        }
-                        _uiShared.DrawHelpText("This setting will disable animation sync for all non-sticky pairs in newly joined syncshells.");
-                        if (ImGui.Checkbox("Disable Syncshell pair VFX", ref disableGroupVFX))
-                        {
-                            perms.DisableGroupVFX = disableGroupVFX;
-                            _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
-                        }
-                        _uiShared.DrawHelpText("This setting will disable VFX sync for all non-sticky pairs in newly joined syncshells.");
+                        UiSharedService.AttachToolTip("Hold CTRL to delete this secret key entry");
                     }
                     else
                     {
-                        UiSharedService.ColorTextWrapped("Default Permission Settings unavailable for this service. " +
-                            "You need to connect to this service to change the default permissions since they are stored on the service.", ImGuiColors.DalamudYellow);
+                        UiSharedService.ColorTextWrapped("This key is in use and cannot be deleted", ImGuiColors.DalamudYellow);
                     }
 
-                    ImGui.EndTabItem();
+                    if (item.Key != selectedServer.SecretKeys.Keys.LastOrDefault())
+                        ImGui.Separator();
                 }
 
-                if (ImGui.BeginTabItem("Account & Data"))
+                ImGui.Separator();
+                if (_uiShared.IconTextButton(FontAwesomeIcon.Plus, "Add new Secret Key"))
                 {
-                    if (_apiController.IsServerConnected(_lastSelectedServerIndex))
+                    selectedServer.SecretKeys.Add(selectedServer.SecretKeys.Any() ? selectedServer.SecretKeys.Max(p => p.Key) + 1 : 0, new SecretKey()
                     {
-                        UiSharedService.ColorTextWrapped("For any changes to be applied to a connected service you need to reconnect to the service after your changes.", ImGuiColors.DalamudYellow);
-                    }
-
-                    if (ApiController.IsServerAlive(_lastSelectedServerIndex))
-                    {
-                        _uiShared.BigText($"Service Actions for {_lastSelectedServerName}");
-                        ImGuiHelpers.ScaledDummy(new Vector2(5, 5));
-                        if (ImGui.Button("Delete all my files"))
-                        {
-                            _deleteFilesPopupModalShown = true;
-                            ImGui.OpenPopup("Delete all your files?");
-                        }
-
-                        _uiShared.DrawHelpText($"Completely deletes all your uploaded files on the {_lastSelectedServerName} service.");
-
-                        if (ImGui.BeginPopupModal("Delete all your files?", ref _deleteFilesPopupModalShown, UiSharedService.PopupWindowFlags))
-                        {
-                            UiSharedService.TextWrapped($"All your own uploaded files on the {_lastSelectedServerName} service will be deleted.\nThis operation cannot be undone.");
-                            ImGui.TextUnformatted("Are you sure you want to continue?");
-                            ImGui.Separator();
-                            ImGui.Spacing();
-
-                            var buttonSize = (ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X -
-                                             ImGui.GetStyle().ItemSpacing.X) / 2;
-
-                            if (ImGui.Button("Delete everything", new Vector2(buttonSize, 0)))
-                            {
-                                _ = Task.Run(() => _fileTransferManager.DeleteAllFiles(_lastSelectedServerIndex));
-                                _deleteFilesPopupModalShown = false;
-                            }
-
-                            ImGui.SameLine();
-
-                            if (ImGui.Button("Cancel##cancelDelete", new Vector2(buttonSize, 0)))
-                            {
-                                _deleteFilesPopupModalShown = false;
-                            }
-
-                            UiSharedService.SetScaledWindowSize(325);
-                            ImGui.EndPopup();
-                        }
-                        ImGui.SameLine();
-                        if (ImGui.Button("Delete account"))
-                        {
-                            _deleteAccountPopupModalShown = true;
-                            ImGui.OpenPopup("Delete your account?");
-                        }
-
-                        _uiShared.DrawHelpText("Completely deletes your account and all uploaded files to the service.");
-
-                        if (ImGui.BeginPopupModal("Delete your account?", ref _deleteAccountPopupModalShown, UiSharedService.PopupWindowFlags))
-                        {
-                            UiSharedService.TextWrapped($"Your account and all associated files and data on the {_lastSelectedServerName} service will be deleted.");
-                            UiSharedService.TextWrapped("Your UID will be removed from all pairing lists.");
-                            ImGui.TextUnformatted("Are you sure you want to continue?");
-                            ImGui.Separator();
-                            ImGui.Spacing();
-
-                            var buttonSize = (ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X -
-                                              ImGui.GetStyle().ItemSpacing.X) / 2;
-
-                            if (ImGui.Button("Delete account", new Vector2(buttonSize, 0)))
-                            {
-                                _ = Task.Run(() => ApiController.UserDelete(_lastSelectedServerIndex));
-                                _deleteAccountPopupModalShown = false;
-                                Mediator.Publish(new SwitchToIntroUiMessage());
-                            }
-
-                            ImGui.SameLine();
-
-                            if (ImGui.Button("Cancel##cancelDelete", new Vector2(buttonSize, 0)))
-                            {
-                                _deleteAccountPopupModalShown = false;
-                            }
-
-                            UiSharedService.SetScaledWindowSize(325);
-                            ImGui.EndPopup();
-                        }
-                    }
-
-                    ImGui.EndTabItem();
+                        FriendlyName = "New Secret Key",
+                    });
+                    _serverConfigurationManager.Save();
                 }
 
-                ImGui.EndTabBar();
+                ImGui.EndTabItem();
             }
+
+            if (ImGui.BeginTabItem("Permission Settings"))
+            {
+                _uiShared.BigText("Default Permission Settings");
+                if (_apiController.IsServerConnected(_lastSelectedServerIndex))
+                {
+                    UiSharedService.TextWrapped("Note: The default permissions settings here are not applied retroactively to existing pairs or joined Syncshells.");
+                    UiSharedService.TextWrapped("Note: The default permissions settings here are sent and stored on the connected service.");
+                    ImGuiHelpers.ScaledDummy(5f);
+                    var perms = _apiController.GetDefaultPermissionsForServer(_lastSelectedServerIndex)!;
+                    bool individualIsSticky = perms.IndividualIsSticky;
+                    bool disableIndividualSounds = perms.DisableIndividualSounds;
+                    bool disableIndividualAnimations = perms.DisableIndividualAnimations;
+                    bool disableIndividualVFX = perms.DisableIndividualVFX;
+                    if (ImGui.Checkbox("Individually set permissions become preferred permissions", ref individualIsSticky))
+                    {
+                        perms.IndividualIsSticky = individualIsSticky;
+                        _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                    }
+                    _uiShared.DrawHelpText("The preferred attribute means that the permissions to that user will never change through any of your permission changes to Syncshells " +
+                        "(i.e. if you have paused one specific user in a Syncshell and they become preferred permissions, then pause and unpause the same Syncshell, the user will remain paused - " +
+                        "if a user does not have preferred permissions, it will follow the permissions of the Syncshell and be unpaused)." + Environment.NewLine + Environment.NewLine +
+                        "This setting means:" + Environment.NewLine +
+                        "  - All new individual pairs get their permissions defaulted to preferred permissions." + Environment.NewLine +
+                        "  - All individually set permissions for any pair will also automatically become preferred permissions. This includes pairs in Syncshells." + Environment.NewLine + Environment.NewLine +
+                        "It is possible to remove or set the preferred permission state for any pair at any time." + Environment.NewLine + Environment.NewLine +
+                        "If unsure, leave this setting off.");
+                    ImGuiHelpers.ScaledDummy(3f);
+
+                    if (ImGui.Checkbox("Disable individual pair sounds", ref disableIndividualSounds))
+                    {
+                        perms.DisableIndividualSounds = disableIndividualSounds;
+                        _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                    }
+                    _uiShared.DrawHelpText("This setting will disable sound sync for all new individual pairs.");
+                    if (ImGui.Checkbox("Disable individual pair animations", ref disableIndividualAnimations))
+                    {
+                        perms.DisableIndividualAnimations = disableIndividualAnimations;
+                        _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                    }
+                    _uiShared.DrawHelpText("This setting will disable animation sync for all new individual pairs.");
+                    if (ImGui.Checkbox("Disable individual pair VFX", ref disableIndividualVFX))
+                    {
+                        perms.DisableIndividualVFX = disableIndividualVFX;
+                        _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                    }
+                    _uiShared.DrawHelpText("This setting will disable VFX sync for all new individual pairs.");
+                    ImGuiHelpers.ScaledDummy(5f);
+                    bool disableGroundSounds = perms.DisableGroupSounds;
+                    bool disableGroupAnimations = perms.DisableGroupAnimations;
+                    bool disableGroupVFX = perms.DisableGroupVFX;
+                    if (ImGui.Checkbox("Disable Syncshell pair sounds", ref disableGroundSounds))
+                    {
+                        perms.DisableGroupSounds = disableGroundSounds;
+                        _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                    }
+                    _uiShared.DrawHelpText("This setting will disable sound sync for all non-sticky pairs in newly joined syncshells.");
+                    if (ImGui.Checkbox("Disable Syncshell pair animations", ref disableGroupAnimations))
+                    {
+                        perms.DisableGroupAnimations = disableGroupAnimations;
+                        _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                    }
+                    _uiShared.DrawHelpText("This setting will disable animation sync for all non-sticky pairs in newly joined syncshells.");
+                    if (ImGui.Checkbox("Disable Syncshell pair VFX", ref disableGroupVFX))
+                    {
+                        perms.DisableGroupVFX = disableGroupVFX;
+                        _ = _apiController.UserUpdateDefaultPermissions(_lastSelectedServerIndex, perms);
+                    }
+                    _uiShared.DrawHelpText("This setting will disable VFX sync for all non-sticky pairs in newly joined syncshells.");
+                }
+                else
+                {
+                    UiSharedService.ColorTextWrapped("Default Permission Settings unavailable for this service. " +
+                        "You need to connect to this service to change the default permissions since they are stored on the service.", ImGuiColors.DalamudYellow);
+                }
+
+                ImGui.EndTabItem();
+            }
+
+            if (ImGui.BeginTabItem("Account & Data"))
+            {
+                if (_apiController.IsServerConnected(_lastSelectedServerIndex))
+                {
+                    UiSharedService.ColorTextWrapped("For any changes to be applied to a connected service you need to reconnect to the service after your changes.", ImGuiColors.DalamudYellow);
+                }
+
+                if (ApiController.IsServerAlive(_lastSelectedServerIndex))
+                {
+                    _uiShared.BigText($"Service Actions for {_lastSelectedServerName}");
+                    ImGuiHelpers.ScaledDummy(new Vector2(5, 5));
+                    if (ImGui.Button("Delete all my files"))
+                    {
+                        _deleteFilesPopupModalShown = true;
+                        ImGui.OpenPopup("Delete all your files?");
+                    }
+
+                    _uiShared.DrawHelpText($"Completely deletes all your uploaded files on the {_lastSelectedServerName} service.");
+
+                    if (ImGui.BeginPopupModal("Delete all your files?", ref _deleteFilesPopupModalShown, UiSharedService.PopupWindowFlags))
+                    {
+                        UiSharedService.TextWrapped($"All your own uploaded files on the {_lastSelectedServerName} service will be deleted.\nThis operation cannot be undone.");
+                        ImGui.TextUnformatted("Are you sure you want to continue?");
+                        ImGui.Separator();
+                        ImGui.Spacing();
+
+                        var buttonSize = (ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X -
+                                         ImGui.GetStyle().ItemSpacing.X) / 2;
+
+                        if (ImGui.Button("Delete everything", new Vector2(buttonSize, 0)))
+                        {
+                            _ = Task.Run(() => _fileTransferManager.DeleteAllFiles(_lastSelectedServerIndex));
+                            _deleteFilesPopupModalShown = false;
+                        }
+
+                        ImGui.SameLine();
+
+                        if (ImGui.Button("Cancel##cancelDelete", new Vector2(buttonSize, 0)))
+                        {
+                            _deleteFilesPopupModalShown = false;
+                        }
+
+                        UiSharedService.SetScaledWindowSize(325);
+                        ImGui.EndPopup();
+                    }
+                    ImGui.SameLine();
+                    if (ImGui.Button("Delete account"))
+                    {
+                        _deleteAccountPopupModalShown = true;
+                        ImGui.OpenPopup("Delete your account?");
+                    }
+
+                    _uiShared.DrawHelpText("Completely deletes your account and all uploaded files to the service.");
+
+                    if (ImGui.BeginPopupModal("Delete your account?", ref _deleteAccountPopupModalShown, UiSharedService.PopupWindowFlags))
+                    {
+                        UiSharedService.TextWrapped($"Your account and all associated files and data on the {_lastSelectedServerName} service will be deleted.");
+                        UiSharedService.TextWrapped("Your UID will be removed from all pairing lists.");
+                        ImGui.TextUnformatted("Are you sure you want to continue?");
+                        ImGui.Separator();
+                        ImGui.Spacing();
+
+                        var buttonSize = (ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X -
+                                          ImGui.GetStyle().ItemSpacing.X) / 2;
+
+                        if (ImGui.Button("Delete account", new Vector2(buttonSize, 0)))
+                        {
+                            _ = Task.Run(() => ApiController.UserDelete(_lastSelectedServerIndex));
+                            _deleteAccountPopupModalShown = false;
+                            Mediator.Publish(new SwitchToIntroUiMessage());
+                        }
+
+                        ImGui.SameLine();
+
+                        if (ImGui.Button("Cancel##cancelDelete", new Vector2(buttonSize, 0)))
+                        {
+                            _deleteAccountPopupModalShown = false;
+                        }
+
+                        UiSharedService.SetScaledWindowSize(325);
+                        ImGui.EndPopup();
+                    }
+                }
+
+                ImGui.EndTabItem();
+            }
+
+            ImGui.EndTabBar();
         }
     }
 
@@ -2071,12 +2072,15 @@ public class SettingsUi : WindowMediatorSubscriberBase
 
     private void DrawSettingsContent()
     {
-        if (!_serverConfigurationManager.ServerIndexes.Contains(_lastSelectedServerIndex))
+        if (_serverConfigurationManager.AnyServerRegistered)
         {
-            _lastSelectedServerIndex = _serverConfigurationManager.ServerIndexes.FirstOrDefault();
-        }
+            if (!_serverConfigurationManager.ServerIndexes.Contains(_lastSelectedServerIndex))
+            {
+                _lastSelectedServerIndex = _serverConfigurationManager.ServerIndexes.FirstOrDefault();
+            }
 
-        _lastSelectedServerName = _apiController.GetServerNameByIndex(_lastSelectedServerIndex);
+            _lastSelectedServerName = _apiController.GetServerNameByIndex(_lastSelectedServerIndex);
+        }
 
         if (_apiController.IsServerConnected(_lastSelectedServerIndex))
         {

--- a/LaciSynchroni/UI/UISharedService.cs
+++ b/LaciSynchroni/UI/UISharedService.cs
@@ -895,10 +895,11 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
         return _serverSelectionIndex;
     }
 
-    public void DrawAddCustomService()
+    public void DrawAddCustomService(bool defaultOpen = false)
     {
+        var defaultOpenFlag = defaultOpen ? ImGuiTreeNodeFlags.DefaultOpen : ImGuiTreeNodeFlags.None;
         ImGuiHelpers.ScaledDummy(5);
-        if (ImGui.TreeNode("Add New Service"))
+        if (ImRaii.TreeNode("Add New Service", defaultOpenFlag))
         {
             ImGui.SetNextItemWidth(250);
             ImGui.InputText("Custom Service Name", ref _customServerName, 255);

--- a/LaciSynchroni/WebAPI/SignalR/ApiController.cs
+++ b/LaciSynchroni/WebAPI/SignalR/ApiController.cs
@@ -49,7 +49,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         AutoConnectClients();
     }
 
-    public ServerState GetServerState(ServerIndex index)
+    public ServerState GetServerStateForServer(ServerIndex index)
     {
         return GetClientForServer(index)?._serverState ?? ServerState.Offline;
     }
@@ -57,6 +57,12 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
     public bool IsServerConnected(int index)
     {
         return GetClientForServer(index)?._serverState == ServerState.Connected;
+    }
+
+    public bool IsServerConnectingOrConnected(int index)
+    {
+        var serverState = GetClientForServer(index)?._serverState;
+        return serverState is (ServerState.Connected or ServerState.Connecting or ServerState.Reconnecting);
     }
 
     public string GetServerNameByIndex(ServerIndex index)
@@ -71,7 +77,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
 
     public bool IsServerAlive(int index)
     {
-        var serverState = GetServerState(index);
+        var serverState = GetServerStateForServer(index);
         return serverState is ServerState.Connected or ServerState.RateLimited
             or ServerState.Unauthorized or ServerState.Disconnected;
     }
@@ -92,12 +98,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
     public DefaultPermissionsDto? GetDefaultPermissionsForServer(ServerIndex index)
     {
         return GetClientForServer(index)?.ConnectionDto?.DefaultPreferredPermissions;
-    }
-
-    public ServerState GetServerStateForServer(ServerIndex index)
-    {
-        // No client found means it's offline
-        return GetClientForServer(index)?._serverState ?? ServerState.Offline;
     }
 
     public bool AnyServerConnected


### PR DESCRIPTION
bugfix: #34 This fixes the scenario of a service being deleted and the settings ui going blank. It also addresses deleting of servers and disabling the controls.
bugfix: Changed GetServerIndex to return an empty class should the server index not match any configured service instead of throwing an exception and breaking other parts of the UI.
feat: CompactUI service list will now show more statuses from the server (reconnecting, disconnecting, connecting, etc) and not only offline/online.