### PR TITLE
Feature: Cleanup on connection/reconnect code and extra documentation on methods

### DIFF
--- a/LaciSynchroni/Services/CharaData/CharaDataGposeTogetherManager.cs
+++ b/LaciSynchroni/Services/CharaData/CharaDataGposeTogetherManager.cs
@@ -7,6 +7,7 @@ using LaciSynchroni.Interop;
 using LaciSynchroni.Interop.Ipc;
 using LaciSynchroni.Services.CharaData.Models;
 using LaciSynchroni.Services.Mediator;
+using LaciSynchroni.Utils;
 using LaciSynchroni.WebAPI;
 using Microsoft.Extensions.Logging;
 using System.Globalization;
@@ -157,7 +158,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
     internal void CreateNewLobby(int serverIndex)
     {
         _dataServerIndex = serverIndex;
-        _ = Task.Run(async () =>
+        TaskHelpers.FireAndForget(async () =>
         {
             try
             {
@@ -174,12 +175,12 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
             {
                 Logger.LogError(ex, "Error creating new GPose Lobby");
             }
-        });
+        }, Logger);
     }
 
     internal void JoinGPoseLobby(int serverIndex, string joinLobbyId, bool isReconnecting = false)
     {
-        _ = Task.Run(async () =>
+        TaskHelpers.FireAndForget(async () =>
         {
             try
             {
@@ -217,12 +218,12 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
                     CurrentGPoseLobbyServerId = null;
                 }
             }
-        });
+        }, Logger);
     }
 
     internal void LeaveGPoseLobby(int serverIndex)
     {
-        _ = Task.Run(async () =>
+        TaskHelpers.FireAndForget(async () =>
         {
             try
             {
@@ -242,7 +243,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
             {
                 Logger.LogError(ex, "Error leaving GPose Lobby");
             }
-        });
+        }, Logger);
     }
 
     protected override void Dispose(bool disposing)
@@ -575,7 +576,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
                 kvp.Value.HasPoseDataUpdate = false;
                 kvp.Value.HasWorldDataUpdate = false;
 
-                _ = Task.Run(async () =>
+                TaskHelpers.FireAndForget(async () =>
                 {
                     if (hadPoseDataUpdate && kvp.Value.ApplicablePoseData != null)
                     {
@@ -585,7 +586,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
                     {
                         await _brio.ApplyTransformAsync(kvp.Value.Address, kvp.Value.WorldData.Value).ConfigureAwait(false);
                     }
-                });
+                }, Logger);
             }
         }
     }

--- a/LaciSynchroni/Services/CharaData/CharaDataGposeTogetherManager.cs
+++ b/LaciSynchroni/Services/CharaData/CharaDataGposeTogetherManager.cs
@@ -35,6 +35,10 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
     // whenever we load data, we set this index. This way, we know which server the data belongs to.
     private int _dataServerIndex;
 
+    public string? CurrentGPoseLobbyId { get; private set; }
+    public int? CurrentGPoseLobbyServerId { get; private set; }
+    public string? LastGPoseLobbyId { get; private set; }
+
     public CharaDataGposeTogetherManager(ILogger<CharaDataGposeTogetherManager> logger, SyncMediator mediator,
             ApiController apiController, IpcCallerBrio brio, DalamudUtilService dalamudUtil, VfxSpawnManager vfxSpawnManager,
         CharaDataFileHandler charaDataFileHandler, CharaDataManager charaDataManager) : base(logger, mediator)
@@ -108,10 +112,6 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
         _charaDataManager = charaDataManager;
     }
 
-    public string? CurrentGPoseLobbyId { get; private set; }
-    public int? CurrentGPoseLobbyServerId { get; private set; }
-    public string? LastGPoseLobbyId { get; private set; }
-
     public IEnumerable<GposeLobbyUserData> UsersInLobby => _usersInLobby.Values;
 
     public (bool SameMap, bool SameServer, bool SameEverything) IsOnSameMapAndServer(GposeLobbyUserData data)
@@ -159,13 +159,20 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
         _dataServerIndex = serverIndex;
         _ = Task.Run(async () =>
         {
-            ClearLobby();
-            CurrentGPoseLobbyId = await _apiController.GposeLobbyCreate(serverIndex).ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(CurrentGPoseLobbyId))
+            try
             {
-                CurrentGPoseLobbyServerId = serverIndex;
-                _ = GposeWorldPositionBackgroundTask(serverIndex, _lobbyCts.Token);
-                _ = GposePoseDataBackgroundTask(serverIndex, _lobbyCts.Token);
+                ClearLobby();
+                CurrentGPoseLobbyId = await _apiController.GposeLobbyCreate(serverIndex).ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(CurrentGPoseLobbyId))
+                {
+                    CurrentGPoseLobbyServerId = serverIndex;
+                    _ = GposeWorldPositionBackgroundTask(serverIndex, _lobbyCts.Token);
+                    _ = GposePoseDataBackgroundTask(serverIndex, _lobbyCts.Token);
+                }
+            }
+            catch(Exception ex)
+            {
+                Logger.LogError(ex, "Error creating new GPose Lobby");
             }
         });
     }
@@ -174,28 +181,41 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
     {
         _ = Task.Run(async () =>
         {
-            var otherUsers = await _apiController.GposeLobbyJoin(serverIndex, joinLobbyId).ConfigureAwait(false);
-            ClearLobby();
-            _dataServerIndex = serverIndex;
-            if (otherUsers.Any())
+            try
             {
-                LastGPoseLobbyId = string.Empty;
-
-                foreach (var user in otherUsers)
+                var otherUsers = await _apiController.GposeLobbyJoin(serverIndex, joinLobbyId).ConfigureAwait(false);
+                ClearLobby();
+                _dataServerIndex = serverIndex;
+                if (otherUsers.Any())
                 {
-                    OnUserJoinLobby(serverIndex, user);
-                }
+                    LastGPoseLobbyId = string.Empty;
 
-                CurrentGPoseLobbyId = joinLobbyId;
-                CurrentGPoseLobbyServerId = serverIndex;
-                _ = GposeWorldPositionBackgroundTask(serverIndex, _lobbyCts.Token);
-                _ = GposePoseDataBackgroundTask(serverIndex, _lobbyCts.Token);
+                    foreach (var user in otherUsers)
+                    {
+                        OnUserJoinLobby(serverIndex, user);
+                    }
+
+                    CurrentGPoseLobbyId = joinLobbyId;
+                    CurrentGPoseLobbyServerId = serverIndex;
+                    _ = GposeWorldPositionBackgroundTask(serverIndex, _lobbyCts.Token);
+                    _ = GposePoseDataBackgroundTask(serverIndex, _lobbyCts.Token);
+                }
+                else
+                {
+                    LeaveGPoseLobby(serverIndex);
+                    LastGPoseLobbyId = string.Empty;
+                    CurrentGPoseLobbyServerId = null;
+                }
             }
-            else
+            catch (Exception ex)
             {
-                LeaveGPoseLobby(serverIndex);
-                LastGPoseLobbyId = string.Empty;
-                CurrentGPoseLobbyServerId = null;
+                Logger.LogError(ex, "Error joining GPose Lobby");
+                if (!isReconnecting)
+                {
+                    ClearLobby();
+                    LastGPoseLobbyId = string.Empty;
+                    CurrentGPoseLobbyServerId = null;
+                }
             }
         });
     }
@@ -204,16 +224,23 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
     {
         _ = Task.Run(async () =>
         {
-            var left = await _apiController.GposeLobbyLeave(serverIndex).ConfigureAwait(false);
-            if (left)
+            try
             {
-                if (_usersInLobby.Count != 0)
+                var left = await _apiController.GposeLobbyLeave(serverIndex).ConfigureAwait(false);
+                if (left)
                 {
-                    LastGPoseLobbyId = CurrentGPoseLobbyId;
-                }
+                    if (_usersInLobby.Count != 0)
+                    {
+                        LastGPoseLobbyId = CurrentGPoseLobbyId;
+                    }
 
-                ClearLobby(revertCharas: true);
-                CurrentGPoseLobbyServerId = null;
+                    ClearLobby(revertCharas: true);
+                    CurrentGPoseLobbyServerId = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error leaving GPose Lobby");
             }
         });
     }

--- a/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
+++ b/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
@@ -81,31 +81,31 @@ public class ServerConfigurationManager
         var auth = currentServer.Authentications.FindAll(f => string.Equals(f.CharacterName, charaName) && f.WorldId == worldId);
         if (auth.Count >= 2)
         {
-            _logger.LogTrace("GetOAuth2 accessed, returning null because multiple ({count}) identical characters.", auth.Count);
+            _logger.LogTrace("GetOAuth2 accessed, returning null because multiple ({Count}) identical characters.", auth.Count);
             hasMulti = true;
             return null;
         }
 
         if (auth.Count == 0)
         {
-            _logger.LogTrace("GetOAuth2 accessed, returning null because no set up characters for {chara} on {world}", charaName, worldId);
+            _logger.LogTrace("GetOAuth2 accessed, returning null because no set up characters for {Chara} on {World}", charaName, worldId);
             return null;
         }
 
         if (auth.Single().LastSeenCID != cid)
         {
             auth.Single().LastSeenCID = cid;
-            _logger.LogTrace("GetOAuth2 accessed, updating CID for {chara} on {world} to {cid}", charaName, worldId, cid);
+            _logger.LogTrace("GetOAuth2 accessed, updating CID for {Chara} on {World} to {Cid}", charaName, worldId, cid);
             Save();
         }
 
         if (!string.IsNullOrEmpty(auth.Single().UID) && !string.IsNullOrEmpty(currentServer.OAuthToken))
         {
-            _logger.LogTrace("GetOAuth2 accessed, returning {key} ({keyValue}) for {chara} on {world}", auth.Single().UID, string.Join("", currentServer.OAuthToken.Take(10)), charaName, worldId);
+            _logger.LogTrace("GetOAuth2 accessed, returning {Key} ({KeyValue}) for {Chara} on {World}", auth.Single().UID, string.Join("", currentServer.OAuthToken.Take(10)), charaName, worldId);
             return (currentServer.OAuthToken, auth.Single().UID!);
         }
 
-        _logger.LogTrace("GetOAuth2 accessed, returning null because no UID found for {chara} on {world} or OAuthToken is not configured.", charaName, worldId);
+        _logger.LogTrace("GetOAuth2 accessed, returning null because no UID found for {Chara} on {World} or OAuthToken is not configured.", charaName, worldId);
 
         return null;
     }
@@ -134,31 +134,31 @@ public class ServerConfigurationManager
         var auth = currentServer.Authentications.FindAll(f => string.Equals(f.CharacterName, charaName, StringComparison.Ordinal) && f.WorldId == worldId);
         if (auth.Count >= 2)
         {
-            _logger.LogTrace("GetSecretKey accessed, returning null because multiple ({count}) identical characters.", auth.Count);
+            _logger.LogTrace("GetSecretKey accessed, returning null because multiple ({Count}) identical characters.", auth.Count);
             hasMulti = true;
             return null;
         }
 
         if (auth.Count == 0)
         {
-            _logger.LogTrace("GetSecretKey accessed, returning null because no set up characters for {chara} on {world}", charaName, worldId);
+            _logger.LogTrace("GetSecretKey accessed, returning null because no set up characters for {Chara} on {World}", charaName, worldId);
             return null;
         }
 
         if (auth.Single().LastSeenCID != cid)
         {
             auth.Single().LastSeenCID = cid;
-            _logger.LogTrace("GetSecretKey accessed, updating CID for {chara} on {world} to {cid}", charaName, worldId, cid);
+            _logger.LogTrace("GetSecretKey accessed, updating CID for {Chara} on {World} to {Cid}", charaName, worldId, cid);
             Save();
         }
 
         if (currentServer.SecretKeys.TryGetValue(auth.Single().SecretKeyIdx, out var secretKey))
         {
-            _logger.LogTrace("GetSecretKey accessed, returning {key} ({keyValue}) for {chara} on {world}", secretKey.FriendlyName, string.Join("", secretKey.Key.Take(10)), charaName, worldId);
+            _logger.LogTrace("GetSecretKey accessed, returning {Key} ({KeyValue}) for {Chara} on {World}", secretKey.FriendlyName, string.Join("", secretKey.Key.Take(10)), charaName, worldId);
             return secretKey.Key;
         }
 
-        _logger.LogTrace("GetSecretKey accessed, returning null because no fitting key found for {chara} on {world} for idx {idx}.", charaName, worldId, auth.Single().SecretKeyIdx);
+        _logger.LogTrace("GetSecretKey accessed, returning null because no fitting key found for {Chara} on {World} for idx {Idx}.", charaName, worldId, auth.Single().SecretKeyIdx);
 
         return null;
     }
@@ -172,7 +172,7 @@ public class ServerConfigurationManager
     {
         return GetServerByIndex(index).ServerName;
     }
-    
+
     public ServerStorage GetServerByIndex(int idx)
     {
         return _serverConfigService.Current.ServerStorage[idx];
@@ -223,7 +223,7 @@ public class ServerConfigurationManager
     public void Save()
     {
         var caller = new StackTrace().GetFrame(1)?.GetMethod()?.ReflectedType?.Name ?? "Unknown";
-        _logger.LogDebug("{caller} Calling config save", caller);
+        _logger.LogDebug("{Caller} Calling config save", caller);
         _serverConfigService.Save();
     }
 

--- a/LaciSynchroni/UI/CompactUI.cs
+++ b/LaciSynchroni/UI/CompactUI.cs
@@ -925,7 +925,7 @@ public class CompactUi : WindowMediatorSubscriberBase
             ServerState.MultiChara => "Your Character Configuration has multiple characters configured with same name and world. You will not be able to connect until you fix this issue. Remove the duplicates from the configuration in Settings -> Service Settings -> Character Management and reconnect manually after.",
             ServerState.OAuthMisconfigured => "OAuth2 is enabled but not fully configured, verify in the Settings -> Service Settings that you have OAuth2 connected and, importantly, a UID assigned to your current character.",
             ServerState.OAuthLoginTokenStale => "Your OAuth2 login token is stale and cannot be used to renew. Go to the Settings -> Service Settings and unlink then relink your OAuth2 configuration.",
-            ServerState.NoAutoLogon => "This character has automatic login disabled for all servers. Press the connect button to connect to a server.",
+            ServerState.NoAutoLogon => "This character has automatic login disabled for the server. Press the connect button to connect to a server.",
             ServerState.NoHubFound => "Sync Hub not found. Please request the correct Hub URI from the person running the server you want to connect to.",
             _ => string.Empty
         };

--- a/LaciSynchroni/UI/Components/DrawUserPair.cs
+++ b/LaciSynchroni/UI/Components/DrawUserPair.cs
@@ -99,7 +99,7 @@ public class DrawUserPair
 
         if (_uiSharedService.IconTextButton(FontAwesomeIcon.PlayCircle, "Cycle pause state", _menuWidth, true))
         {
-            _ = _apiController.CyclePauseAsync(_pair.ServerIndex, _pair.UserData);
+            _apiController.CyclePauseAsync(_pair.ServerIndex, _pair.UserData);
             ImGui.CloseCurrentPopup();
         }
         ImGui.Separator();

--- a/LaciSynchroni/Utils/TaskHelpers.cs
+++ b/LaciSynchroni/Utils/TaskHelpers.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
+
+namespace LaciSynchroni.Utils
+{
+    /// <summary>
+    /// Helper methods for working with tasks.
+    /// </summary>
+    public static class TaskHelpers
+    {
+        /// <summary>
+        /// Run a task in the background, catching and logging any unhandled exceptions.
+        /// </summary>
+        public static void FireAndForget(Func<Task> taskFunc, ILogger? logger = null, CancellationToken? token = null, [CallerMemberName] string callerName = "")
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    if (token.HasValue)
+                        await taskFunc().WaitAsync(token.Value).ConfigureAwait(false);
+                    else
+                        await taskFunc().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected cancellation, ignore
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex, "Unhandled exception in fire-and-forget task called by ({CallerName}): ", callerName);
+                }
+            });
+        }
+    }
+}

--- a/LaciSynchroni/Utils/UriBuilderExtensions.cs
+++ b/LaciSynchroni/Utils/UriBuilderExtensions.cs
@@ -5,6 +5,10 @@
     /// </summary>
     public static class UriBuilderExtensions
     {
+        /// <summary>
+        /// Convert ws/wss scheme to http/https.
+        /// </summary>
+        /// <returns></returns>
         public static UriBuilder WsToHttp(this UriBuilder uriBuilder)
         {
             if (string.Equals(uriBuilder.Scheme, Uri.UriSchemeWss, StringComparison.OrdinalIgnoreCase))
@@ -15,6 +19,10 @@
             return uriBuilder;
         }
 
+        /// <summary>
+        /// Convert http/https scheme to ws/wss.
+        /// </summary>
+        /// <returns></returns>
         public static UriBuilder HttpToWss(this UriBuilder uriBuilder)
         {
             if (string.Equals(uriBuilder.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))

--- a/LaciSynchroni/Utils/UriBuilderExtensions.cs
+++ b/LaciSynchroni/Utils/UriBuilderExtensions.cs
@@ -23,7 +23,7 @@
         /// Convert http/https scheme to ws/wss.
         /// </summary>
         /// <returns></returns>
-        public static UriBuilder HttpToWss(this UriBuilder uriBuilder)
+        public static UriBuilder HttpToWs(this UriBuilder uriBuilder)
         {
             if (string.Equals(uriBuilder.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                 uriBuilder.Scheme = Uri.UriSchemeWss;

--- a/LaciSynchroni/Utils/UriBuilderExtensions.cs
+++ b/LaciSynchroni/Utils/UriBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿namespace LaciSynchroni.Utils
+{
+    /// <summary>
+    /// Extensions for <see cref="UriBuilder"/>.
+    /// </summary>
+    public static class UriBuilderExtensions
+    {
+        public static UriBuilder WsToHttp(this UriBuilder uriBuilder)
+        {
+            if (string.Equals(uriBuilder.Scheme, Uri.UriSchemeWss, StringComparison.OrdinalIgnoreCase))
+                uriBuilder.Scheme = Uri.UriSchemeHttps;
+            else if (string.Equals(uriBuilder.Scheme, Uri.UriSchemeWs, StringComparison.OrdinalIgnoreCase))
+                uriBuilder.Scheme = Uri.UriSchemeHttp;
+
+            return uriBuilder;
+        }
+
+        public static UriBuilder HttpToWss(this UriBuilder uriBuilder)
+        {
+            if (string.Equals(uriBuilder.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                uriBuilder.Scheme = Uri.UriSchemeWss;
+            else if (string.Equals(uriBuilder.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+                uriBuilder.Scheme = Uri.UriSchemeWs;
+
+            return uriBuilder;
+        }
+    }
+}

--- a/LaciSynchroni/WebAPI/SignalR/ApiController.cs
+++ b/LaciSynchroni/WebAPI/SignalR/ApiController.cs
@@ -54,46 +54,26 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         AutoConnectClients();
     }
 
-    /// <summary>
-    /// Gets the server state for the given server index.
-    /// </summary>
-    /// <returns></returns>
     public ServerState GetServerState(ServerIndex index)
     {
         return GetClientForServer(index)?.ServerState ?? ServerState.Offline;
     }
 
-    /// <summary>
-    /// Returns true if the server at the given index is connected.
-    /// </summary>
-    /// <returns></returns>
     public bool IsServerConnected(ServerIndex index)
     {
         return GetClientForServer(index)?.ServerState == ServerState.Connected;
     }
 
-    /// <summary>
-    /// Gets the server name for the given server index.
-    /// </summary>
-    /// <returns></returns>
     public string GetServerNameByIndex(ServerIndex index)
     {
         return _serverConfigManager.GetServerByIndex(index).ServerName ?? string.Empty;
     }
 
-    /// <summary>
-    /// Gets the number of online users for the given server index.
-    /// </summary>
-    /// <returns></returns>
     public int GetOnlineUsersForServer(ServerIndex index)
     {
         return GetClientForServer(index)?.SystemInfoDto?.OnlineUsers ?? 0;
     }
 
-    /// <summary>
-    /// Returns true if the server is in a state that it can be considered "alive", meaning it's not offline or in an error state.
-    /// </summary>
-    /// <returns></returns>
     public bool IsServerAlive(int index)
     {
         var serverState = GetServerState(index);
@@ -101,9 +81,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
             or ServerState.Unauthorized or ServerState.Disconnected;
     }
 
-    /// <summary>
-    /// Gets the total number of online users across all connected servers.
-    /// </summary>
     public int OnlineUsers
     {
         get
@@ -112,37 +89,22 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
     }
 
-    /// <summary>
-    /// Gets the server info for the given server index.
-    /// </summary>
-    /// <returns></returns>
     public ServerInfo? GetServerInfoForServer(ServerIndex index)
     {
         return GetClientForServer(index)?.ConnectionDto?.ServerInfo;
     }
 
-    /// <summary>
-    /// Gets the default permissions for the given server index.
-    /// </summary>
-    /// <returns></returns>
     public DefaultPermissionsDto? GetDefaultPermissionsForServer(ServerIndex index)
     {
         return GetClientForServer(index)?.ConnectionDto?.DefaultPreferredPermissions;
     }
 
-    /// <summary>
-    /// Gets the server state for the given server index.
-    /// </summary>
-    /// <returns></returns>
     public ServerState GetServerStateForServer(ServerIndex index)
     {
         // No client found means it's offline
         return GetClientForServer(index)?.ServerState ?? ServerState.Offline;
     }
 
-    /// <summary>
-    /// Returns true if any server is currently connected.
-    /// </summary>
     public bool AnyServerConnected
     {
         get
@@ -151,9 +113,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
     }
 
-    /// <summary>
-    /// Returns true if any server is currently in the process of connecting.
-    /// </summary>
     public bool AnyServerConnecting
     {
         get
@@ -162,9 +121,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
     }
 
-    /// <summary>
-    /// Returns true if any server is currently in the process of disconnecting.
-    /// </summary>
     public bool AnyServerDisconnecting
     {
         get
@@ -173,9 +129,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
     }
 
-    /// <summary>
-    /// Gets the indexes of all currently connected servers.
-    /// </summary>
     public int[] ConnectedServerIndexes {
         get
         {
@@ -183,65 +136,36 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
     }
 
-    /// <summary>
-    /// Returns true if the server at the given index is in the process of connecting state.
-    /// </summary>
-    /// <returns></returns>
     public bool IsServerConnecting(ServerIndex index)
     {
         return GetServerStateForServer(index) == ServerState.Connecting;
     }
 
-    /// <summary>
-    /// Gets the maximum number of syncshells a user can join on the given server.
-    /// </summary>
-    /// <returns></returns>
     public int GetMaxGroupsJoinedByUser(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.ConnectionDto?.ServerInfo.MaxGroupsJoinedByUser ?? 0;
     }
 
-    /// <summary>
-    /// Gets the maximum number of syncshells a user can create on the given server.
-    /// </summary>
-    /// <param name="serverIndex"></param>
-    /// <returns></returns>
     public int GetMaxGroupsCreatedByUser(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.ConnectionDto?.ServerInfo.MaxGroupsCreatedByUser ?? 0;
     }
 
-    /// <summary>
-    /// Gets the authentication failure message for the given server index, if any.
-    /// </summary>
-    /// <returns></returns>
     public string? GetAuthFailureMessageByServer(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.AuthFailureMessage;
     }
 
-    /// <summary>
-    /// Gets the UID of the connected user for the given server index, or an empty string if not connected.
-    /// </summary>
-    /// <returns></returns>
     public string GetUidByServer(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.UID ?? string.Empty;
     }
 
-    /// <summary>
-    /// Gets the display name (alias or UID) of the connected user for the given server index, or an empty string if not connected.
-    /// </summary>
-    /// <returns></returns>
     public string GetDisplayNameByServer(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.ConnectionDto?.User.AliasOrUID ?? string.Empty;
     }
 
-    /// <summary>
-    /// Pauses the connection to the server at the given index, disposing of the client.
-    /// </summary>
-    /// <returns></returns>
     public async Task PauseConnectionAsync(ServerIndex serverIndex)
     {
         _syncHubClients.TryRemove(serverIndex, out SyncHubClient? removed);
@@ -251,18 +175,11 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
     }
 
-    /// <summary>
-    /// Creates connections for the server at the given index, if not already connected.
-    /// </summary>
-    /// <returns></returns>
     public async Task CreateConnectionsAsync(ServerIndex serverIndex)
     {
         await ConnectMultiClient(serverIndex).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Cycles the pause state of the connection for the server at the given index.
-    /// </summary>
     public void CyclePauseAsync(ServerIndex serverIndex, UserData userData)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -271,20 +188,12 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
             TaskHelpers.FireAndForget(() => client.CyclePauseAsync(serverIndex, userData), Logger, cts.Token);
     }
 
-    /// <summary>
-    /// Creates a new SyncHubClient for the given server index.
-    /// </summary>
-    /// <returns></returns>
     private SyncHubClient CreateNewClient(ServerIndex serverIndex)
     {
         return new SyncHubClient(serverIndex, _serverConfigManager, _pairManager, _dalamudUtil,
             _loggerFactory, _loggerProvider, Mediator, _multiConnectTokenService, _syncConfigService, _httpClient);
     }
 
-    /// <summary>
-    /// Gets the SyncHubClient for the given server index, or null if not found.
-    /// </summary>
-    /// <returns></returns>
     private SyncHubClient? GetClientForServer(ServerIndex serverIndex)
     {
         _syncHubClients.TryGetValue(serverIndex, out var client);
@@ -292,10 +201,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
 
     }
 
-    /// <summary>
-    /// Gets or creates the SyncHubClient for the given server index.
-    /// </summary>
-    /// <returns></returns>
     private SyncHubClient GetOrCreateForServer(ServerIndex serverIndex, [CallerMemberName] string callerName = "")
     {
         Logger.LogDebug("({CallerName}) GetOrCreateForServer: serverIndex={ServerIndex}", callerName, serverIndex);
@@ -303,24 +208,16 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         return client;
     }
 
-    /// <summary>
-    /// Connects the SyncHubClient for the given server index, creating it if necessary.
-    /// </summary>
-    /// <returns></returns>
     private Task ConnectMultiClient(ServerIndex serverIndex)
     {
         return GetOrCreateForServer(serverIndex).CreateConnectionsAsync();
     }
 
-    /// <summary>
-    /// Automatically connects clients for all servers that are not fully paused.
-    /// </summary>
     public void AutoConnectClients()
     {
         Mediator.Publish(new EventMessage(new Event(nameof(ApiController), EventSeverity.Informational,
             $"Auto-connecting clients initiated.")));
 
-        // Fire and forget the auto connect. if something goes wrong, it'll be displayed in UI
         using var cts = new CancellationTokenSource();
         TaskHelpers.FireAndForget(async () =>
         {
@@ -340,9 +237,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }, Logger, cts.Token);
     }
 
-    /// <summary>
-    /// Disposes all clients and their connections when the ApiController is disposed.
-    /// </summary>
     protected override void Dispose(bool disposing)
     {
         if(disposing)
@@ -354,10 +248,6 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         base.Dispose(disposing);
     }
 
-    /// <summary>
-    /// Disposes all connections on all sync clients registered.
-    /// </summary>
-    /// <returns></returns>
     private async Task DisposeAllClientsAsync()
     {
         var disposeTasks = _syncHubClients.Values

--- a/LaciSynchroni/WebAPI/SignalR/ApiController.cs
+++ b/LaciSynchroni/WebAPI/SignalR/ApiController.cs
@@ -2,12 +2,15 @@
 using LaciSynchroni.Common.Dto;
 using LaciSynchroni.PlayerData.Pairs;
 using LaciSynchroni.Services;
+using LaciSynchroni.Services.Events;
 using LaciSynchroni.Services.Mediator;
 using LaciSynchroni.Services.ServerConfiguration;
 using LaciSynchroni.SyncConfiguration;
+using LaciSynchroni.Utils;
 using LaciSynchroni.WebAPI.SignalR.Utils;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace LaciSynchroni.WebAPI;
 using ServerIndex = int;
@@ -34,7 +37,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
     /// No more usage of ServerConfigurationManager#Current server
     /// Down the line, we move this into a list or a Map of active servers.
     /// </summary>
-    private readonly ConcurrentDictionary<ServerIndex, SyncHubClient> _syncClients = new();
+    private readonly ConcurrentDictionary<ServerIndex, SyncHubClient> _syncHubClients = new();
 
     public ApiController(ILogger<ApiController> logger, ILoggerFactory loggerFactory, DalamudUtilService dalamudUtil, ILoggerProvider loggerProvider,
         PairManager pairManager, ServerConfigurationManager serverConfigManager, SyncMediator mediator, MultiConnectTokenService multiConnectTokenService, SyncConfigService syncConfigService, HttpClient httpClient) : base(logger, mediator)
@@ -51,26 +54,46 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         AutoConnectClients();
     }
 
+    /// <summary>
+    /// Gets the server state for the given server index.
+    /// </summary>
+    /// <returns></returns>
     public ServerState GetServerState(ServerIndex index)
     {
-        return GetClientForServer(index)?._serverState ?? ServerState.Offline;
+        return GetClientForServer(index)?.ServerState ?? ServerState.Offline;
     }
 
-    public bool IsServerConnected(int index)
+    /// <summary>
+    /// Returns true if the server at the given index is connected.
+    /// </summary>
+    /// <returns></returns>
+    public bool IsServerConnected(ServerIndex index)
     {
-        return GetClientForServer(index)?._serverState == ServerState.Connected;
+        return GetClientForServer(index)?.ServerState == ServerState.Connected;
     }
 
+    /// <summary>
+    /// Gets the server name for the given server index.
+    /// </summary>
+    /// <returns></returns>
     public string GetServerNameByIndex(ServerIndex index)
     {
         return _serverConfigManager.GetServerByIndex(index).ServerName ?? string.Empty;
     }
 
+    /// <summary>
+    /// Gets the number of online users for the given server index.
+    /// </summary>
+    /// <returns></returns>
     public int GetOnlineUsersForServer(ServerIndex index)
     {
         return GetClientForServer(index)?.SystemInfoDto?.OnlineUsers ?? 0;
     }
 
+    /// <summary>
+    /// Returns true if the server is in a state that it can be considered "alive", meaning it's not offline or in an error state.
+    /// </summary>
+    /// <returns></returns>
     public bool IsServerAlive(int index)
     {
         var serverState = GetServerState(index);
@@ -78,163 +101,268 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
             or ServerState.Unauthorized or ServerState.Disconnected;
     }
 
+    /// <summary>
+    /// Gets the total number of online users across all connected servers.
+    /// </summary>
     public int OnlineUsers
     {
         get
         {
-            return _syncClients.Sum(entry => entry.Value.SystemInfoDto?.OnlineUsers ?? 0);
+            return _syncHubClients.Sum(entry => entry.Value.SystemInfoDto?.OnlineUsers ?? 0);
         }
     }
 
+    /// <summary>
+    /// Gets the server info for the given server index.
+    /// </summary>
+    /// <returns></returns>
     public ServerInfo? GetServerInfoForServer(ServerIndex index)
     {
         return GetClientForServer(index)?.ConnectionDto?.ServerInfo;
     }
 
+    /// <summary>
+    /// Gets the default permissions for the given server index.
+    /// </summary>
+    /// <returns></returns>
     public DefaultPermissionsDto? GetDefaultPermissionsForServer(ServerIndex index)
     {
         return GetClientForServer(index)?.ConnectionDto?.DefaultPreferredPermissions;
     }
 
+    /// <summary>
+    /// Gets the server state for the given server index.
+    /// </summary>
+    /// <returns></returns>
     public ServerState GetServerStateForServer(ServerIndex index)
     {
         // No client found means it's offline
-        return GetClientForServer(index)?._serverState ?? ServerState.Offline;
+        return GetClientForServer(index)?.ServerState ?? ServerState.Offline;
     }
 
+    /// <summary>
+    /// Returns true if any server is currently connected.
+    /// </summary>
     public bool AnyServerConnected
     {
         get
         {
-            return _syncClients.Any(client => client.Value._serverState == ServerState.Connected);
+            return _syncHubClients.Any(client => client.Value.ServerState == ServerState.Connected);
         }
     }
 
+    /// <summary>
+    /// Returns true if any server is currently in the process of connecting.
+    /// </summary>
     public bool AnyServerConnecting
     {
         get
         {
-            return _syncClients.Any(client => client.Value._serverState == ServerState.Connecting);
+            return _syncHubClients.Any(client => client.Value.ServerState == ServerState.Connecting);
         }
     }
 
+    /// <summary>
+    /// Returns true if any server is currently in the process of disconnecting.
+    /// </summary>
     public bool AnyServerDisconnecting
     {
         get
         {
-            return _syncClients.Any(client => client.Value._serverState == ServerState.Disconnecting);
+            return _syncHubClients.Any(client => client.Value.ServerState == ServerState.Disconnecting);
         }
     }
 
+    /// <summary>
+    /// Gets the indexes of all currently connected servers.
+    /// </summary>
     public int[] ConnectedServerIndexes {
         get
         {
-            return [.._syncClients.Where(p=> p.Value._serverState == ServerState.Connected)?.Select(p=> p.Key) ?? []];
+            return [.._syncHubClients.Where(p=> p.Value.ServerState == ServerState.Connected)?.Select(p=> p.Key) ?? []];
         }
     }
 
+    /// <summary>
+    /// Returns true if the server at the given index is in the process of connecting state.
+    /// </summary>
+    /// <returns></returns>
     public bool IsServerConnecting(ServerIndex index)
     {
         return GetServerStateForServer(index) == ServerState.Connecting;
     }
 
+    /// <summary>
+    /// Gets the maximum number of syncshells a user can join on the given server.
+    /// </summary>
+    /// <returns></returns>
     public int GetMaxGroupsJoinedByUser(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.ConnectionDto?.ServerInfo.MaxGroupsJoinedByUser ?? 0;
     }
 
+    /// <summary>
+    /// Gets the maximum number of syncshells a user can create on the given server.
+    /// </summary>
+    /// <param name="serverIndex"></param>
+    /// <returns></returns>
     public int GetMaxGroupsCreatedByUser(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.ConnectionDto?.ServerInfo.MaxGroupsCreatedByUser ?? 0;
     }
 
+    /// <summary>
+    /// Gets the authentication failure message for the given server index, if any.
+    /// </summary>
+    /// <returns></returns>
     public string? GetAuthFailureMessageByServer(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.AuthFailureMessage;
     }
 
+    /// <summary>
+    /// Gets the UID of the connected user for the given server index, or an empty string if not connected.
+    /// </summary>
+    /// <returns></returns>
     public string GetUidByServer(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.UID ?? string.Empty;
     }
 
+    /// <summary>
+    /// Gets the display name (alias or UID) of the connected user for the given server index, or an empty string if not connected.
+    /// </summary>
+    /// <returns></returns>
     public string GetDisplayNameByServer(ServerIndex serverIndex)
     {
         return GetClientForServer(serverIndex)?.ConnectionDto?.User.AliasOrUID ?? string.Empty;
     }
 
+    /// <summary>
+    /// Pauses the connection to the server at the given index, disposing of the client.
+    /// </summary>
+    /// <returns></returns>
     public async Task PauseConnectionAsync(ServerIndex serverIndex)
     {
-        _syncClients.TryRemove(serverIndex, out SyncHubClient? removed);
+        _syncHubClients.TryRemove(serverIndex, out SyncHubClient? removed);
         if (removed != null)
         {
-            await removed.DisposeAsync().ConfigureAwait(false);
+            await removed.DisposeConnectionAsync().ConfigureAwait(false);
         }
     }
 
+    /// <summary>
+    /// Creates connections for the server at the given index, if not already connected.
+    /// </summary>
+    /// <returns></returns>
     public async Task CreateConnectionsAsync(ServerIndex serverIndex)
     {
         await ConnectMultiClient(serverIndex).ConfigureAwait(false);
     }
 
-    public Task CyclePauseAsync(ServerIndex serverIndex, UserData userData)
+    /// <summary>
+    /// Cycles the pause state of the connection for the server at the given index.
+    /// </summary>
+    public void CyclePauseAsync(ServerIndex serverIndex, UserData userData)
     {
-        var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromSeconds(5));
-        _ = Task.Run(async () =>
-        {
-            await GetOrCreateForServer(serverIndex).CyclePauseAsync(serverIndex, userData).ConfigureAwait(false);
-        }, cts.Token);
-        return Task.CompletedTask;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var client = GetClientForServer(serverIndex);
+        if (client is not null)
+            TaskHelpers.FireAndForget(() => client.CyclePauseAsync(serverIndex, userData), Logger, cts.Token);
     }
 
+    /// <summary>
+    /// Creates a new SyncHubClient for the given server index.
+    /// </summary>
+    /// <returns></returns>
     private SyncHubClient CreateNewClient(ServerIndex serverIndex)
     {
         return new SyncHubClient(serverIndex, _serverConfigManager, _pairManager, _dalamudUtil,
             _loggerFactory, _loggerProvider, Mediator, _multiConnectTokenService, _syncConfigService, _httpClient);
     }
 
+    /// <summary>
+    /// Gets the SyncHubClient for the given server index, or null if not found.
+    /// </summary>
+    /// <returns></returns>
     private SyncHubClient? GetClientForServer(ServerIndex serverIndex)
     {
-        _syncClients.TryGetValue(serverIndex, out var client);
+        _syncHubClients.TryGetValue(serverIndex, out var client);
+        return client;
+
+    }
+
+    /// <summary>
+    /// Gets or creates the SyncHubClient for the given server index.
+    /// </summary>
+    /// <returns></returns>
+    private SyncHubClient GetOrCreateForServer(ServerIndex serverIndex, [CallerMemberName] string callerName = "")
+    {
+        Logger.LogDebug("({CallerName}) GetOrCreateForServer: serverIndex={ServerIndex}", callerName, serverIndex);
+        var client = _syncHubClients.GetOrAdd(serverIndex, CreateNewClient);
         return client;
     }
 
-    private SyncHubClient GetOrCreateForServer(ServerIndex serverIndex)
-    {
-        return _syncClients.GetOrAdd(serverIndex, CreateNewClient);
-    }
-
+    /// <summary>
+    /// Connects the SyncHubClient for the given server index, creating it if necessary.
+    /// </summary>
+    /// <returns></returns>
     private Task ConnectMultiClient(ServerIndex serverIndex)
     {
         return GetOrCreateForServer(serverIndex).CreateConnectionsAsync();
     }
 
+    /// <summary>
+    /// Automatically connects clients for all servers that are not fully paused.
+    /// </summary>
     public void AutoConnectClients()
     {
+        Mediator.Publish(new EventMessage(new Event(nameof(ApiController), EventSeverity.Informational,
+            $"Auto-connecting clients initiated.")));
+
         // Fire and forget the auto connect. if something goes wrong, it'll be displayed in UI
-        _ = Task.Run(async () =>
+        using var cts = new CancellationTokenSource();
+        TaskHelpers.FireAndForget(async () =>
         {
+            var charaName = await _dalamudUtil.GetPlayerNameAsync().ConfigureAwait(false);
+            var worldId = await _dalamudUtil.GetHomeWorldIdAsync().ConfigureAwait(false);
+
+            Logger.LogInformation("Auto-connecting clients for character {Character} on world {WorldId}", charaName, worldId);
+
             foreach (int serverIndex in _serverConfigManager.ServerIndexes)
             {
                 var server = _serverConfigManager.GetServerByIndex(serverIndex);
                 if (!server.FullPause)
                 {
-                    await GetOrCreateForServer(serverIndex).DalamudUtilOnLogIn().ConfigureAwait(false);
+                    await GetOrCreateForServer(serverIndex).DalamudUtilOnLogIn(charaName, worldId).ConfigureAwait(false);
                 }
             }
-        });
+        }, Logger, cts.Token);
     }
 
+    /// <summary>
+    /// Disposes all clients and their connections when the ApiController is disposed.
+    /// </summary>
     protected override void Dispose(bool disposing)
     {
-        // We can always just Dispose() this - even if not used
-        foreach (var syncHubClient in _syncClients.Values)
+        if(disposing)
         {
-            syncHubClient.Dispose();
+            _ = DisposeAllClientsAsync();
+            _syncHubClients.Clear();
         }
-        _syncClients.Clear();
+
         base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Disposes all connections on all sync clients registered.
+    /// </summary>
+    /// <returns></returns>
+    private async Task DisposeAllClientsAsync()
+    {
+        var disposeTasks = _syncHubClients.Values
+            .Select(client => client.DisposeConnectionAsync());
+        await Task.WhenAll(disposeTasks).ConfigureAwait(false);
     }
 }
 #pragma warning restore MA0040

--- a/LaciSynchroni/WebAPI/SignalR/ApiController.cs
+++ b/LaciSynchroni/WebAPI/SignalR/ApiController.cs
@@ -347,7 +347,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
     {
         if(disposing)
         {
-            _ = DisposeAllClientsAsync();
+            DisposeAllClientsAsync().GetAwaiter().GetResult();
             _syncHubClients.Clear();
         }
 

--- a/LaciSynchroni/WebAPI/SignalR/SyncHubClient.Functions.Groups.cs
+++ b/LaciSynchroni/WebAPI/SignalR/SyncHubClient.Functions.Groups.cs
@@ -120,6 +120,6 @@ public partial class SyncHubClient : IServerHub
 
     private void CheckConnection()
     {
-        if (_serverState is not (ServerState.Connected or ServerState.Connecting or ServerState.Reconnecting)) throw new InvalidDataException("Not connected");
+        if (ServerState is not (ServerState.Connected or ServerState.Connecting or ServerState.Reconnecting)) throw new InvalidDataException("Not connected");
     }
 }

--- a/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
+++ b/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
@@ -189,7 +189,7 @@ public partial class SyncHubClient : DisposableMediatorSubscriberBase, IServerHu
         {
             // Just make sure no open connection exists. It shouldn't, but can't hurt (At least I assume that was the intent...)
             // Also set to "Connecting" at this point
-            Logger.LogInformation("Already connected to {ServerName}, stopping connection", _serverName);
+            Logger.LogDebug("Already connected to {ServerName}, stopping connection", _serverName);
             await StopConnectionAsync(ServerState.Connecting).ConfigureAwait(false);
         }
 

--- a/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
+++ b/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
@@ -362,7 +362,7 @@ public partial class SyncHubClient : DisposableMediatorSubscriberBase, IServerHu
         if (!await VerifyClientVersion(ConnectionDto).ConfigureAwait(false))
         {
             await StopConnectionAsync(ServerState.VersionMisMatch).ConfigureAwait(false);
-            throw new HttpRequestException($"Client version mismatch with service{_serverName}: Server {ConnectionDto.ServerVersion}", null, HttpStatusCode.BadRequest);
+           Logger.LogWarning("Client version mismatch with service {ServerName}: {ServerVersion}", _serverName, ConnectionDto.ServerVersion);
         }
         // Also trigger some warnings
         TriggerConnectionWarnings(ConnectionDto);

--- a/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
+++ b/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
@@ -212,6 +212,7 @@ public partial class SyncHubClient : DisposableMediatorSubscriberBase, IServerHu
                 }
 
                 ServerState = ServerState.Reconnecting;
+                _logger.LogInformation("Failed to establish connection to {ServerName}, retrying", ServerName);
                 await Task.Delay(TimeSpan.FromSeconds(new Random().Next(5, 20)), connectionCancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
### Features
Added extension class for Running tasks as "fire and forget". This should be safer and log exceptions properly without propagating errors to other parts of the application.
Added UriBuilderExtension class, with WsToHttp and HttpToWs, as proprosed by @Cytraen
Added exception logging to Gpose Together methods.
Added progressively increasing delay to reconnect after each failure, stopping at 60 seconds.
Created FireAndForget extension method, which can be used to replaced unsafe Task.Run methods and add extra logging.

### Bugfixes
Proper handling of the cancellation tokens, so tasks are properly stopped if the operation is cancelled. Cancellation Tokens should be disposed safely.
Changed NoAutoLogon message to state the configuration is for the current server, not all.

### Documentation
Added documentation for methods and public properties on SyncHubClient.
Added the server name to log messages on SyncHubClient and ApiController.
Added additional logging in the SyncHubClient methods.
