### PR TITLE
Bugfix: Token leak after get UID call

### DIFF
--- a/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
+++ b/LaciSynchroni/Services/ServerConfiguration/ServerConfigurationManager.cs
@@ -478,8 +478,9 @@ public class ServerConfigurationManager
         {
             var baseUri = serverUri.Replace("wss://", "https://").Replace("ws://", "http://");
             var oauthCheckUri = AuthRoutes.GetUIDsFullPath(new Uri(baseUri));
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            var response = await _httpClient.GetAsync(oauthCheckUri).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Get, oauthCheckUri);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
             var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             return await JsonSerializer.DeserializeAsync<Dictionary<string, string>>(responseStream).ConfigureAwait(false) ?? [];
         }


### PR DESCRIPTION
Resolves an issue that leaked the mare JWT to all outgoing requests that did not override the Authentication header after calling Update UIDs