### PR TITLE
fix: Resolves an issue with data not being loaded for the right service in CDO

### DIFF
--- a/LaciSynchroni/UI/CharaDataHubUi.McdOnline.cs
+++ b/LaciSynchroni/UI/CharaDataHubUi.McdOnline.cs
@@ -597,7 +597,7 @@ internal sealed partial class CharaDataHubUi
         {
             if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Download your Character Data from Server"))
             {
-                _ = _charaDataManager.GetAllData(_selectedServerIndex, _disposalCts.Token);
+                _ = _charaDataManager.GetAllData(_disposalCts.Token);
             }
         }
         if (_charaDataManager.DataGetTimeoutTask != null && !_charaDataManager.DataGetTimeoutTask.IsCompleted)

--- a/LaciSynchroni/UI/CharaDataHubUi.NearbyPoses.cs
+++ b/LaciSynchroni/UI/CharaDataHubUi.NearbyPoses.cs
@@ -200,7 +200,7 @@ internal partial class CharaDataHubUi
         {
             if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Update Data Shared With You"))
             {
-                _ = _charaDataManager.GetAllSharedData(_selectedServerIndex, _disposalCts.Token).ContinueWith(u => UpdateFilteredItems());
+                _ = _charaDataManager.GetAllSharedData(_disposalCts.Token).ContinueWith(u => UpdateFilteredItems());
             }
         }
         if (_charaDataManager.GetSharedWithYouTimeoutTask != null && !_charaDataManager.GetSharedWithYouTimeoutTask.IsCompleted)

--- a/LaciSynchroni/UI/CharaDataHubUi.cs
+++ b/LaciSynchroni/UI/CharaDataHubUi.cs
@@ -116,7 +116,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         _serverSelector = new ServerSelectorSmall(index =>
         {
             _selectedServerIndex = index;
-            _ = _charaDataManager.GetAllData(_selectedServerIndex, _disposalCts.Token);
+            _ = _charaDataManager.SelectServer(_selectedServerIndex, _disposalCts.Token);
         }, _apiController.ConnectedServerIndexes.FirstOrDefault());
     }
 
@@ -478,7 +478,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
                                 {
                                     if (_uiSharedService.IconButton(FontAwesomeIcon.ArrowsSpin))
                                     {
-                                        _charaDataManager.DownloadMetaInfo(_selectedServerIndex, favorite.Key, false);
+                                        _charaDataManager.DownloadMetaInfo(favorite.Key, false);
                                         UpdateFilteredItems();
                                     }
                                 }
@@ -565,7 +565,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
                         {
                             if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Get Info from Sharing Code"))
                             {
-                                _charaDataManager.DownloadMetaInfo(_selectedServerIndex, _importCode);
+                                _charaDataManager.DownloadMetaInfo(_importCode);
                             }
                         }
                         GposeMetaInfoAction((meta) =>
@@ -635,7 +635,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
                         {
                             if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Download your Character Data"))
                             {
-                                _ = _charaDataManager.GetAllData(_selectedServerIndex, _disposalCts.Token);
+                                _ = _charaDataManager.GetAllData(_disposalCts.Token);
                             }
                         }
                         if (_charaDataManager.DataGetTimeoutTask != null && !_charaDataManager.DataGetTimeoutTask.IsCompleted)

--- a/LaciSynchroni/WebAPI/SignalR/ApiController.cs
+++ b/LaciSynchroni/WebAPI/SignalR/ApiController.cs
@@ -251,5 +251,14 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
         _syncClients.Clear();
     }
+
+    public ConnectionDto? GetConnectionDto(ServerIndex serverIndex)
+    {
+        if (!IsServerConnected(serverIndex))
+        {
+            return null;
+        }
+        return _syncClients[serverIndex].ConnectionDto;
+    }
 }
 #pragma warning restore MA0040


### PR DESCRIPTION
A few usages of the server index as parameter were removed. When the server selector swaps the server, data is cleared
and data is reloaded. That is mostly for code flow reasons, since adding the server index is superfluous for anything calling the chara data manager