### PR TITLE
bugfix: Update hub URL logic to respect UseAdvancedUris flag

### DIFF
--- a/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
+++ b/LaciSynchroni/WebAPI/SignalR/SyncHubClient.cs
@@ -233,7 +233,9 @@ public partial class SyncHubClient : DisposableMediatorSubscriberBase, IServerHu
 
     private async Task<string?> FindHubUrl()
     {
-        var configuredHubUri = ServerToUse.ServerHubUri.Replace("wss://", "https://").Replace("ws://", "http://");
+        var configuredHubUri = ServerToUse.UseAdvancedUris
+            ? ServerToUse.ServerHubUri.Replace("wss://", "https://").Replace("ws://", "http://")
+            : string.Empty;
         var baseUri = ServerToUse.ServerUri.Replace("wss://", "https://").Replace("ws://", "http://");
         if (baseUri.EndsWith("/", StringComparison.Ordinal))
         {


### PR DESCRIPTION
Fixes #83. Modified FindHubUrl to set configuredHubUri only if UseAdvancedUris is true; otherwise, it is set to an empty string. This change ensures that advanced URI replacement is conditional based on the server configuration.