### PR TITLE
Refactor file transfer management for thread safety

### DIFF
--- a/LaciSynchroni/WebAPI/Files/FileDownloadManager.cs
+++ b/LaciSynchroni/WebAPI/Files/FileDownloadManager.cs
@@ -230,10 +230,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
 
         foreach (var dto in downloadFileInfoFromService.Where(c => c.IsForbidden))
         {
-            if (!_orchestrator.ForbiddenTransfers.Exists(f => string.Equals(f.Hash, dto.Hash, StringComparison.Ordinal)))
-            {
-                _orchestrator.ForbiddenTransfers.Add(new DownloadFileTransfer(dto, serverIndex));
-            }
+            _orchestrator.TryAddForbiddenTransfer(new DownloadFileTransfer(dto, serverIndex));
         }
 
         CurrentDownloads = downloadFileInfoFromService.Distinct().Select(d => new DownloadFileTransfer(d, serverIndex))

--- a/LaciSynchroni/WebAPI/Files/FileTransferOrchestrator.cs
+++ b/LaciSynchroni/WebAPI/Files/FileTransferOrchestrator.cs
@@ -55,7 +55,13 @@ public class FileTransferOrchestrator : DisposableMediatorSubscriberBase
         });
     }
 
-    public List<FileTransfer> ForbiddenTransfers { get; } = [];
+    private readonly ConcurrentDictionary<string, FileTransfer> _forbiddenTransfers = new(StringComparer.Ordinal);
+
+    public List<FileTransfer> ForbiddenTransfers => _forbiddenTransfers.Values.ToList();
+
+    public bool IsForbidden(string hash) => _forbiddenTransfers.ContainsKey(hash);
+
+    public bool TryAddForbiddenTransfer(FileTransfer transfer) => _forbiddenTransfers.TryAdd(transfer.Hash, transfer);
 
     public Uri? GetFileCdnUri(int serverIndex)
     {


### PR DESCRIPTION
Whilst uploads were already safely handled, verification and forbidden lists were not. Replaced List and Dictionary collections with ConcurrentDictionary in FileTransferOrchestrator and FileUploadManager to improve thread safety during concurrent operations. Centralized forbidden transfer logic in FileTransferOrchestrator and updated related usages. Adjusted upload tracking and verification to be per-server.