### PR TITLE
Release render lock on zone switch and cancellation

### DIFF
--- a/LaciSynchroni/PlayerData/Handlers/PairHandler.cs
+++ b/LaciSynchroni/PlayerData/Handlers/PairHandler.cs
@@ -74,7 +74,10 @@ public sealed class PairHandler : DisposableMediatorSubscriberBase
         Mediator.Subscribe<ZoneSwitchStartMessage>(this, (_) =>
         {
             _downloadCancellationTokenSource?.CancelDispose();
+            _applicationCancellationTokenSource = _applicationCancellationTokenSource?.CancelRecreate();
             _charaHandler?.Invalidate();
+			// Release render lock on zone switch to prevent stale ownership blocking other servers
+			_concurrentPairLockService.ReleaseRenderLock(PlayerNameHash, Pair.ServerIndex);
             IsVisible = false;
         });
         Mediator.Subscribe<PenumbraInitializedMessage>(this, (_) =>
@@ -531,9 +534,15 @@ public sealed class PairHandler : DisposableMediatorSubscriberBase
 
             Logger.LogDebug("[{applicationId}] Application finished", _applicationId);
         }
-        catch (Exception ex)
+		catch (OperationCanceledException)
+		{
+			// Release render lock when an application is cancelled so another server can take over
+			_concurrentPairLockService.ReleaseRenderLock(PlayerNameHash, Pair.ServerIndex);
+			Logger.LogDebug("[{applicationId}] Application cancelled", _applicationId);
+		}
+		catch (Exception ex)
         {
-            if (ex is AggregateException aggr && aggr.InnerExceptions.Any(e => e is ArgumentNullException))
+            if (ex is AggregateException aggr && aggr.InnerExceptions.Any(e => e is ArgumentNullException || e is NullReferenceException))
             {
                 IsVisible = false;
                 _forceApplyMods = true;
@@ -544,6 +553,8 @@ public sealed class PairHandler : DisposableMediatorSubscriberBase
             {
                 Logger.LogWarning(ex, "[{applicationId}] Cancelled", _applicationId);
             }
+			// On failures, release render lock to avoid stale ownership
+			_concurrentPairLockService.ReleaseRenderLock(PlayerNameHash, Pair.ServerIndex);
         }
     }
 
@@ -589,6 +600,8 @@ public sealed class PairHandler : DisposableMediatorSubscriberBase
             _charaHandler.Invalidate();
             _downloadCancellationTokenSource?.CancelDispose();
             _downloadCancellationTokenSource = null;
+			// Release render lock when the player is no longer visible
+			_concurrentPairLockService.ReleaseRenderLock(PlayerNameHash, Pair.ServerIndex);
             Logger.LogTrace("{this} visibility changed, now: {visi}", this, IsVisible);
         }
     }
@@ -614,7 +627,17 @@ public sealed class PairHandler : DisposableMediatorSubscriberBase
             await _ipcManager.PetNames.SetPlayerData(PlayerCharacter, _cachedData.PetNamesData).ConfigureAwait(false);
         });
 
-        _ipcManager.Penumbra.AssignTemporaryCollectionAsync(Logger, _penumbraCollection, _charaHandler.GetGameObject()!.ObjectIndex).GetAwaiter().GetResult();
+		// Only the render-lock owner should assign the temp collection to avoid a non-owner overwriting
+		// an already-populated collection with an empty one (which would render the target vanilla).
+		var lockOwner = _concurrentPairLockService.GetRenderLock(PlayerNameHash, Pair.ServerIndex, PlayerName);
+		if (lockOwner == Pair.ServerIndex)
+		{
+			_ipcManager.Penumbra.AssignTemporaryCollectionAsync(Logger, _penumbraCollection, _charaHandler.GetGameObject()!.ObjectIndex).GetAwaiter().GetResult();
+		}
+		else
+		{
+			Logger.LogTrace("Skipping temp collection assignment for {this} - render lock is owned by server {owner}", this, lockOwner);
+		}
     }
 
     private async Task RevertCustomizationDataAsync(ObjectKind objectKind, string name, Guid applicationId, CancellationToken cancelToken)


### PR DESCRIPTION
Added calls to release the render lock when a zone switch occurs, when an application is cancelled, on failures, and when the player is no longer visible. Also updated temporary collection assignment to only occur if the current server owns the render lock, preventing non-owners from overwriting collections and causing rendering issues.