### PR TITLE
chore: bumps PS to v35

### DIFF
--- a/LaciSynchroni/WebAPI/SignalR/SyncHubOverrides/SyncHubClientPS.cs
+++ b/LaciSynchroni/WebAPI/SignalR/SyncHubOverrides/SyncHubClientPS.cs
@@ -21,7 +21,7 @@ internal class SyncHubClientPS : SyncHubClient
         ILoggerFactory loggerFactory, ILoggerProvider loggerProvider, SyncMediator mediator, MultiConnectTokenService multiConnectTokenService, SyncConfigService syncConfigService, HttpClient httpClient) :
         base(serverIndex, serverConfigurationManager, pairManager, dalamudUtilService, loggerFactory, loggerProvider, mediator, multiConnectTokenService, syncConfigService, httpClient)
     {
-        ApiVersion = 34;
+        ApiVersion = 35;
     }
 
     public override async Task UserAddPair(UserDto user)


### PR DESCRIPTION
PS added Loci support, which we don't support. But the rest still works.