### PR TITLE
Update the workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           upload-release-assets: false
           format: spdx-json
-          file: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
+          path: ./bin/LaciSynchroni
           output-file: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
 
       - name: Generate artifact attestation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Build and release
 on:
   push:
     tags:
-#      - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
       - 'testing_[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 
@@ -31,8 +30,8 @@ jobs:
           $tag = '${{ github.ref_name }}'
           $isTesting = $tag.StartsWith('testing_')
           $version = if ($isTesting) { $tag -replace '^testing_', '' } else { $tag }
-          Write-Output "IS_TESTING=$($isTesting.ToString().ToLower())" >> $env:GITHUB_OUTPUT
-          Write-Output "VERSION=$version" >> $env:GITHUB_OUTPUT
+          "IS_TESTING=$($isTesting.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "VERSION=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -50,7 +49,11 @@ jobs:
 
       - name: Get packager manifest
         id: load_packager_manifest
-        run: Write-Output "MANIFEST_JSON<<EOF`n$(Get-Content -Raw ./bin/LaciSynchroni/LaciSynchroni.json)`nEOF" >> $env:GITHUB_OUTPUT
+        run: |
+          $json = Get-Content -Raw ./bin/LaciSynchroni/LaciSynchroni.json
+          "MANIFEST_JSON<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          $json | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Rename artifact
         run: Move-Item -Path ./bin/LaciSynchroni/latest.zip -Destination ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
@@ -61,7 +64,7 @@ jobs:
           upload-release-assets: false
           format: spdx-json
           path: ./bin/LaciSynchroni
-          output-file: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
+          output-file: ./bin/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
@@ -72,7 +75,7 @@ jobs:
         uses: actions/attest-sbom@v3
         with:
           subject-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
-          sbom-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
+          sbom-path: ./bin/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
 
       - name: Create release
         id: create_release
@@ -81,10 +84,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Laci Synchroni ${{ github.ref_name }}
           draft: false
-          prerelease: ${{ steps.version_info.outputs.IS_TESTING }}
+          prerelease: ${{ steps.version_info.outputs.IS_TESTING == 'true' }}
           files: |
             ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
-            ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
+            ./bin/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
 
       - name: Request Repository Update (Generate App Token, 1/2)
         id: app_token
@@ -97,17 +100,26 @@ jobs:
 
       - name: Request Repository Update (Trigger Workflow, 2/2)
         uses: actions/github-script@v8
+        env:
+          MANIFEST_JSON: ${{ steps.load_packager_manifest.outputs.MANIFEST_JSON }}
+          IS_TESTING: ${{ steps.version_info.outputs.IS_TESTING }}
+          PLUGIN_VERSION: ${{ steps.version_info.outputs.VERSION }}
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
-            github.rest.repos.createDispatchEvent({
-              owner: "${{ github.repository_owner }}",
+            const manifest = JSON.parse(process.env.MANIFEST_JSON);
+            const isTesting = process.env.IS_TESTING === 'true';
+            const ref = context.ref.replace('refs/tags/', '');
+            const version = process.env.PLUGIN_VERSION;
+
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
               repo: "repo",
               event_type: "new-release",
               client_payload: {
-                "tag": "${{ github.ref_name }}",
-                "is_testing": ${{ steps.version_info.outputs.IS_TESTING }},
-                "api_level": "${{ fromJSON(steps.load_packager_manifest.outputs.MANIFEST_JSON).DalamudApiLevel }}",
-                "asset_url": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip"
+                "tag": ref,
+                "is_testing": isTesting,
+                "api_level": manifest.DalamudApiLevel,
+                "asset_url": `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/${ref}/LaciSynchroni_v${version}.zip`
               },
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Build and release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+#      - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'testing_[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 
 defaults:
   run:
@@ -23,10 +24,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-
-      - name: Check if testing version
-        id: get_is_testing
-        run: Write-Output "IS_TESTING=$(([Version]::Parse('${{ github.ref_name }}').Revision -gt 0).ToString().ToLower())" >> $env:GITHUB_OUTPUT
+      
+      - name: Parse version info
+        id: version_info
+        run: |
+          $tag = '${{ github.ref_name }}'
+          $isTesting = $tag.StartsWith('testing_')
+          $version = if ($isTesting) { $tag -replace '^testing_', '' } else { $tag }
+          Write-Output "IS_TESTING=$($isTesting.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+          Write-Output "VERSION=$version" >> $env:GITHUB_OUTPUT
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -40,33 +46,33 @@ jobs:
           Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
 
       - name: Build
-        run: dotnet build ./LaciSynchroni/LaciSynchroni.csproj -c Release -o bin /p:ContinuousIntegrationBuild=true /p:Version=${{ github.ref_name }}
+        run: dotnet build ./LaciSynchroni/LaciSynchroni.csproj -c Release -o bin /p:ContinuousIntegrationBuild=true /p:Version=${{ steps.version_info.outputs.VERSION }}
 
       - name: Get packager manifest
         id: load_packager_manifest
         run: Write-Output "MANIFEST_JSON<<EOF`n$(Get-Content -Raw ./bin/LaciSynchroni/LaciSynchroni.json)`nEOF" >> $env:GITHUB_OUTPUT
 
       - name: Rename artifact
-        run: Move-Item -Path ./bin/LaciSynchroni/latest.zip -Destination ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}.zip
+        run: Move-Item -Path ./bin/LaciSynchroni/latest.zip -Destination ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
           upload-release-assets: false
           format: spdx-json
-          file: ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}.zip
-          output-file: ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}_sbom.spdx.json
+          file: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
+          output-file: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}.zip
+          subject-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
 
       - name: Generate SBOM attestation
         uses: actions/attest-sbom@v3
         with:
-          subject-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}.zip
-          sbom-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}_sbom.spdx.json
+          subject-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
+          sbom-path: ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
 
       - name: Create release
         id: create_release
@@ -75,10 +81,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Laci Synchroni ${{ github.ref_name }}
           draft: false
-          prerelease: ${{ steps.get_is_testing.outputs.IS_TESTING }}
+          prerelease: ${{ steps.version_info.outputs.IS_TESTING }}
           files: |
-            ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}.zip
-            ./bin/LaciSynchroni/LaciSynchroni_v${{ github.ref_name }}_sbom.spdx.json
+            ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip
+            ./bin/LaciSynchroni/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}_sbom.spdx.json
 
       - name: Request Repository Update (Generate App Token, 1/2)
         id: app_token
@@ -100,8 +106,8 @@ jobs:
               event_type: "new-release",
               client_payload: {
                 "tag": "${{ github.ref_name }}",
-                "is_testing": ${{ steps.get_is_testing.outputs.IS_TESTING }},
+                "is_testing": ${{ steps.version_info.outputs.IS_TESTING }},
                 "api_level": "${{ fromJSON(steps.load_packager_manifest.outputs.MANIFEST_JSON).DalamudApiLevel }}",
-                "asset_url": "${{ fromJSON(steps.create_release.outputs.assets)[0].browser_download_url }}"
+                "asset_url": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/LaciSynchroni_v${{ steps.version_info.outcome.VERSION }}.zip"
               },
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,6 @@ jobs:
                 "tag": "${{ github.ref_name }}",
                 "is_testing": ${{ steps.version_info.outputs.IS_TESTING }},
                 "api_level": "${{ fromJSON(steps.load_packager_manifest.outputs.MANIFEST_JSON).DalamudApiLevel }}",
-                "asset_url": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/LaciSynchroni_v${{ steps.version_info.outcome.VERSION }}.zip"
+                "asset_url": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/LaciSynchroni_v${{ steps.version_info.outputs.VERSION }}.zip"
               },
             })


### PR DESCRIPTION
This just updates how we release versions of the client plugin.

Release tags are now in the format of `x.y.z.w`, for example `1.0.13.0`.
Testing releases are now in the format of `testing_x.y.z.w`, for example `testing_1.0.14.0`.

I also updated SBOM attestation to use the output files instead of the generated zip, as apparently this was how it's intended in the first place..?

I'm no workflow wizards, and workflows are scary